### PR TITLE
Add redirect from /mcp/overview to introduction page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -195,6 +195,12 @@
      "copy"
    ]
   },
+  "redirects": [
+    {
+      "source": "/mcp/overview",
+      "destination": "/mcp/getting-started/introduction"
+    }
+  ],
   "footer": {
     "socials": {
       "x": "https://x.com/Test_Sprite",


### PR DESCRIPTION
## Summary
- Adds a redirect in `docs.json` so `/mcp/overview` navigates to `/mcp/getting-started/introduction`

## Test plan
- [ ] Visit `/mcp/overview` and verify it redirects to `/mcp/getting-started/introduction`

🤖 Generated with [Claude Code](https://claude.com/claude-code)