### PR TITLE
docs: fix broken internal links and typo

### DIFF
--- a/mcp/concepts/healing-observability.mdx
+++ b/mcp/concepts/healing-observability.mdx
@@ -152,7 +152,7 @@ Healing and observability are embedded across the lifecycle:
   <Card title="MCP Tools Reference" href="/mcp/core/tools">
     Explore TestSprite MCP tools and commands
   </Card>
-  <Card title="Testing Workflow" href="/mcp/concepts/workflow">
+  <Card title="Test Types & Lifecycle" href="/mcp/concepts/test-type-lifecycle">
     Understand the complete testing workflow
   </Card>
   <Card title="Key Terms" href="/mcp/concepts/key-terms">

--- a/mcp/getting-started/first-test.mdx
+++ b/mcp/getting-started/first-test.mdx
@@ -129,7 +129,7 @@ Upload existing PRD (required). Even a draft or low-quality PRD is fine. TestSpr
 
 Your AI assistant will automatically handle the **entire testing process** by running through these steps. It takes care of everything from understanding your project to running the actual tests, so you don't have to do any of the work manually.
 
-Learn more about details steps at [Testing Workflow](../concepts/workflow).
+Learn more about details steps at [Test Types & Lifecycle](../concepts/test-type-lifecycle).
 
 ## Step 5: Review Test Results
 

--- a/mcp/getting-started/introduction.mdx
+++ b/mcp/getting-started/introduction.mdx
@@ -32,7 +32,7 @@ integration that lets your IDE’s AI assistant orchestrate the entire TestSprit
   <Card title="Run First MCP Test" icon="play" href="first-test">
   Complete your first automated test in 10 minutes
   </Card>
-  <Card title="Testing Workflow" icon="route" href="../concepts/workflow">
+  <Card title="Test Types & Lifecycle" icon="route" href="../concepts/test-type-lifecycle">
   Understand the complete testing workflow
   </Card>
   <Card title="Manage API Keys" icon="key" href="../../web-portal/admin/api-keys">

--- a/mcp/maintenance/test-maintenance.mdx
+++ b/mcp/maintenance/test-maintenance.mdx
@@ -83,7 +83,7 @@ Rerun quickly: `testsprite_rerun_tests({ projectPath: "/abs/path" })`
   <Card title="Modify or Update Tests" href="/mcp/core/modify-tests">
     Learn how to modify and update existing tests
   </Card>
-  <Card title="MCP Testing Workflow" href="/mcp/concepts/workflow">
+  <Card title="Test Types & Lifecycle" href="/mcp/concepts/test-type-lifecycle">
     Understand the MCP testing workflow
   </Card>
   <Card title="MCP Tools Reference" href="/mcp/core/tools">

--- a/web-portal/getting-started/introduction.mdx
+++ b/web-portal/getting-started/introduction.mdx
@@ -20,23 +20,23 @@ Our no-code AI completes testing cycles in **10-20** minutes, so you can ship wi
 
 The TestSprite Web Portal gives you a central place to configure projects, manage API keys, run and monitor tests, and review detailed reports—without leaving the browser.
 
-For UI tests, TestSprite now explores your live app feature by feature before writing any test plan, so the plan reflects how your app really behaves. This **Feature Exploration** phase is currently in Beta — see [Front-End (UI) Testing](../core/ui-testing) for details.
+For UI tests, TestSprite now explores your live app feature by feature before writing any test plan, so the plan reflects how your app really behaves. This **Feature Exploration** phase is currently in Beta — see [Front-End (UI) Testing](/web-portal/core/ui/ui-testing) for details.
 
 <Columns cols={3}>
   <Card title="Overview" icon="book" href="overview">
   Learn what TestSprite Web Portal can do
   </Card>
-  <Card title="Start API Testings" icon="terminal" href="../core/api-testing">
+  <Card title="Start API Testings" icon="terminal" href="/web-portal/core/api/api-testing">
   Start testing your backend on TestSprite Web Portal
   </Card>
-  <Card title="Run UI Testings" icon="window-maximize" href="../core/ui-testing">
+  <Card title="Run UI Testings" icon="window-maximize" href="/web-portal/core/ui/ui-testing">
   Start frontend testing on TestSprite Web Portal
   </Card>
   <Card title="Create Test List" icon="list" href="../maintenance/test-lists">
   Organize tests using Test List
   </Card>
   <Card title="Start Monitoring" icon="chart-simple" href="../maintenance/monitoring">
-  Start continuous scheduling and monitoring for your prjects.
+  Start continuous scheduling and monitoring for your projects.
   </Card>
   <Card title="Join Community" icon="comments" arrow="true" href="https://discord.com/invite/QQB9tJ973e">
   Connect with other users


### PR DESCRIPTION
## Summary
Fixes broken internal links and a typo across MCP and Web Portal docs.

## Changes
- `mcp/concepts/healing-observability.mdx`
- `mcp/getting-started/first-test.mdx`
- `mcp/getting-started/introduction.mdx`
- `mcp/maintenance/test-maintenance.mdx`
- `web-portal/getting-started/introduction.mdx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)