### PR TITLE
docs(cli): rename init/auth commands for the setup consolidation

### DIFF
--- a/cli/concepts/key-terms.mdx
+++ b/cli/concepts/key-terms.mdx
@@ -194,7 +194,7 @@ Every run is tagged with the surface that triggered it. The **run source** lets 
 
 ## Scopes
 
-**Scopes** are permissions that an API key carries. The CLI checks scopes before sending write or run requests, and when access is denied it prints which scope was required and which scopes your key holds. Read commands need read scopes, writes need `write:tests`, and runs need `run:tests`; purely local commands like `init` and `agent install` need none.
+**Scopes** are permissions that an API key carries. The CLI checks scopes before sending write or run requests, and when access is denied it prints which scope was required and which scopes your key holds. Read commands need read scopes, writes need `write:tests`, and runs need `run:tests`; the purely local `agent install` command needs none, and `setup` works with any valid key.
 
 See [Authentication → Scopes](/cli/core/authentication#scopes) for the full table of which scope gates which command.
 

--- a/cli/core/agent-integration.mdx
+++ b/cli/core/agent-integration.mdx
@@ -16,7 +16,7 @@ icon: "robot"
 The skill is **pure-local**: `agent install` reads and writes only to your filesystem. It makes no network requests and requires no credentials.
 
 <Tip>
-**We strongly recommend installing the skill.** It's the fastest way to get consistent results — the skill teaches your agent exactly when to verify, how to read the failure bundle, and how to loop until the test is green, so you don't have to spell it out each time. Run `testsprite init` (or `testsprite agent install`) once per project.
+**We strongly recommend installing the skill.** It's the fastest way to get consistent results — the skill teaches your agent exactly when to verify, how to read the failure bundle, and how to loop until the test is green, so you don't have to spell it out each time. Run `testsprite setup` (or `testsprite agent install`) once per project.
 </Tip>
 
 ## Install the skill
@@ -84,13 +84,13 @@ codex        experimental  managed-section   AGENTS.md
 
 ## One-shot onboarding
 
-`testsprite init` configures your API key **and** installs the skill in a single step — the recommended path when you're setting up a project for the first time.
+`testsprite setup` configures your API key **and** installs the skill in a single step — the recommended path when you're setting up a project for the first time.
 
 ```bash
-testsprite init
+testsprite setup
 ```
 
-`init` chains `auth configure` → `auth whoami` → `agent install` and prints a unified summary.
+`setup` chains credential configuration → identity verification → agent skill install, and prints a unified summary.
 
 <Card title="Installation" href="/cli/getting-started/installation" icon="download" horizontal>
   The full onboarding walkthrough, including the non-interactive (`--from-env --yes`) form for CI bootstrap.

--- a/cli/core/authentication.mdx
+++ b/cli/core/authentication.mdx
@@ -8,34 +8,40 @@ icon: "key"
 
 Before you can run any command that talks to the TestSprite API, you need to store a valid API key.
 
-The fastest path is `testsprite init` — it prompts for the key, verifies it against the server, installs the agent skill into your repo, and prints a unified summary, all in one step:
+The fastest path is `testsprite setup` — it prompts for the key, verifies it against the server, installs the agent skill into your repo, and prints a unified summary, all in one step:
 
 ```bash
-testsprite init
+testsprite setup
 ```
 
 <Card title="Installation" href="/cli/getting-started/installation" icon="download">
   The full onboarding walkthrough
 </Card>
 
-If you want credentials only — no skill install — run:
+If you want credentials only — no skill install — add `--no-agent`:
 
 ```bash
-testsprite auth configure
+testsprite setup --no-agent
 ```
 
-The CLI calls `GET /me` with the key you provide before writing anything to disk. A rejected or malformed key never overwrites a working profile.
+The CLI calls `GET /me` with the key you provide before writing anything to disk. A rejected or malformed key never overwrites a working profile. You are only ever prompted for the API key.
 
 ```text
-# interactive prompt
-? API key: sk-...
-Profile "default" configured. Endpoint: https://api.testsprite.com
+TestSprite API key: ********
+TestSprite initialized.
+
+  profile:  default
+  env:      production
+  email:    you@example.com
+  scopes:   read:me, read:projects, read:tests, write:tests, run:tests
+
+  agent:    skipped (--no-agent)
 ```
 
 For non-interactive environments (CI, Dockerfiles, scripted setup), pass `--from-env` instead of typing at a prompt:
 
 ```bash
-TESTSPRITE_API_KEY=sk-... testsprite auth configure --from-env
+TESTSPRITE_API_KEY=sk-... testsprite setup --from-env --yes --no-agent
 ```
 
 <Warning>
@@ -44,10 +50,10 @@ TESTSPRITE_API_KEY=sk-... testsprite auth configure --from-env
 
 ## Checking who you are
 
-Run `testsprite auth whoami` (alias: `testsprite auth status`) to confirm which key and profile are active:
+Run `testsprite auth status` to confirm which key and profile are active:
 
 ```bash
-testsprite auth whoami
+testsprite auth status
 ```
 
 Sample text output:
@@ -57,7 +63,6 @@ userId    usr_1478d468
 name      Your Name
 email     you@example.com
 keyId     key_a1b2c3d4
-endpoint  https://api.testsprite.com
 env       production
 scopes    read:me, read:projects, read:tests, write:tests, run:tests
 ```
@@ -69,7 +74,7 @@ If your key is missing `write:tests` or `run:tests`, the output appends a `note:
 To remove credentials for the active profile:
 
 ```bash
-testsprite auth logout
+testsprite auth remove
 ```
 
 The credentials entry for the selected profile is deleted from `~/.testsprite/credentials`. Other profiles are not touched.
@@ -86,7 +91,7 @@ api_key = sk-...
 api_key = sk-...
 ```
 
-Each section is a named **profile**. The section name matches the profile you activated when you ran `auth configure`.
+Each section is a named **profile**. The section name matches the profile you activated when you ran `setup`.
 
 ## Profiles
 
@@ -95,7 +100,7 @@ Profiles let you manage multiple accounts or API keys (for example, an interacti
 To configure a named profile, pass `--profile` before the subcommand:
 
 ```bash
-testsprite --profile ci auth configure
+testsprite --profile ci setup --no-agent
 ```
 
 To use a profile for any subsequent command, pass `--profile` as a global flag:
@@ -135,14 +140,14 @@ API keys carry a list of **scopes** that gate which operations the CLI can perfo
 
 | Scope | Gates |
 | :--- | :--- |
-| `read:me` | `auth whoami`, `usage` |
+| `read:me` | `auth status`, `usage` |
 | `read:projects` | `project list`, `project get` |
 | `read:tests` | `test list`, `test get`, `test steps`, `test result`, `test code get`, `test failure get`, `test failure summary`, `test artifact get` |
 | `write:tests` | `test create`, `test create-batch`, `test update`, `test delete`, `test delete-batch`, `test code put`, `test plan put`, `project create`, `project update` |
 | `run:tests` | `test run`, `test wait`, `test rerun` |
 
 <Note>
-`testsprite agent install` is a pure-local operation — it only writes files to your project directory and never calls the API, so no scope is required. `testsprite init` *does* call the API to verify your key (`GET /me`) and fetch your identity, but it works with any valid key and needs no write or run scope.
+`testsprite agent install` is a pure-local operation — it only writes files to your project directory and never calls the API, so no scope is required. `testsprite setup` *does* call the API to verify your key (`GET /me`) and fetch your identity, but it works with any valid key and needs no write or run scope.
 </Note>
 
 If a command fails with a scope error, the CLI prints the required and granted scopes in both text and JSON modes. You can generate a new key with the needed scopes in the dashboard at <kbd>Settings → API Keys</kbd> → <kbd>Create new key</kbd>.

--- a/cli/getting-started/installation.mdx
+++ b/cli/getting-started/installation.mdx
@@ -75,44 +75,49 @@ New and grandfathered keys both default to the scopes the CLI needs: `read:me`, 
 ## Sign In
 
 <Tabs>
-  <Tab title="One-shot (recommended)">
-    Run `testsprite init`. It prompts for your API key, verifies it against the platform, and installs the verification skill into your project's agent configuration — all in one step:
+  <Tab title="With the agent skill (recommended)">
+    Run `testsprite setup`. It prompts for your API key, verifies it against the platform, and installs the verification skill into your project's agent configuration — all in one step:
 
     ```bash
-    testsprite init
+    testsprite setup
     ```
 
     ```text
-    ? API key: sk-...
-    ✔ Authenticated as alice@example.com
-    ✔ Agent skill installed → .claude/skills/testsprite-verify/SKILL.md
+    TestSprite API key: ********
     TestSprite initialized.
+
+      profile:  default
+      env:      production
+      email:    alice@example.com
+      scopes:   read:me, read:projects, read:tests, write:tests, run:tests
+
+      agent:    claude (installed)
+
+    Next steps:
+      testsprite test list            # list tests in the current project
+      testsprite agent list           # check installed agent targets
+      testsprite agent install --target=<t>  # re-install or install additional targets
     ```
 
-    `init` chains credential configuration → identity verification → agent skill install. You only need to run it once per project.
+    `setup` chains credential configuration → identity verification → agent skill install. You only need to run it once per project. Pass `--agent <target>` to pick a different coding agent (default `claude`).
   </Tab>
-  <Tab title="Manual">
-    Configure credentials and verify separately:
+  <Tab title="Credentials only">
+    Add `--no-agent` to configure credentials without installing the agent skill:
 
     ```bash
-    testsprite auth configure
-    ```
-
-    ```text
-    ? API key: sk-...
-    Profile "default" configured. Endpoint: https://api.testsprite.com
+    testsprite setup --no-agent
     ```
 
     Then confirm the identity bound to the key:
 
     ```bash
-    testsprite auth whoami
+    testsprite auth status
     ```
   </Tab>
 </Tabs>
 
 <Tip>
-Use `testsprite init` — it configures credentials, verifies them, and installs the agent skill in one pass. `auth configure` is for cases where you want fine-grained profile control or are scripting a headless setup.
+`testsprite setup` is the single onboarding command — it configures credentials, verifies them, and installs the agent skill in one pass. Add `--no-agent` when you only want credentials.
 </Tip>
 
 ## Verify
@@ -120,7 +125,7 @@ Use `testsprite init` — it configures credentials, verifies them, and installs
 After signing in, confirm the active profile:
 
 ```bash
-testsprite auth whoami
+testsprite auth status
 ```
 
 ```text
@@ -128,19 +133,18 @@ userId    u_01abc...
 name      Alice Example
 email     alice@example.com
 keyId     key_01xyz...
-endpoint  https://api.testsprite.com
 env       production
-scopes    read:me read:projects read:tests write:tests run:tests
+scopes    read:me, read:projects, read:tests, write:tests, run:tests
 ```
 
 If any scopes are missing, the CLI prints a `note:` line telling you which commands will be blocked.
 
 ## Using It in CI
 
-In a CI environment, set `TESTSPRITE_API_KEY` as a secret and use the non-interactive init flag:
+In a CI environment, set `TESTSPRITE_API_KEY` as a secret and run setup non-interactively:
 
 ```bash
-TESTSPRITE_API_KEY=$TS_KEY testsprite init --from-env --yes
+TESTSPRITE_API_KEY=$TS_KEY testsprite setup --from-env --yes
 ```
 
 `--from-env` reads the key from the environment instead of prompting. `--yes` accepts all defaults without interactive prompts. The CLI never accepts the API key as a positional argument or writes it to logs.

--- a/cli/getting-started/overview.mdx
+++ b/cli/getting-started/overview.mdx
@@ -54,11 +54,11 @@ What broke comes back as **one self-consistent failure bundle** the agent can ac
 
 <Steps>
   <Step title="Install and onboard">
-    Install once globally, then run `testsprite init`. It prompts for your API key, verifies it against the platform, and installs the verification skill into your agent's project — so your agent already knows when and how to run tests.
+    Install once globally, then run `testsprite setup`. It prompts for your API key, verifies it against the platform, and installs the verification skill into your agent's project — so your agent already knows when and how to run tests.
 
     ```bash
     npm install -g @testsprite/testsprite-cli
-    testsprite init
+    testsprite setup
     ```
   </Step>
   <Step title="Describe a behavior and create + run a test">

--- a/cli/getting-started/quickstart.mdx
+++ b/cli/getting-started/quickstart.mdx
@@ -16,15 +16,15 @@ Install the CLI globally and run the one-shot onboarding:
 
 ```bash
 npm install -g @testsprite/testsprite-cli
-testsprite init
+testsprite setup
 ```
 
-`testsprite init` prompts for your API key, verifies it, and installs the TestSprite verification skill into your agent's project configuration. Run it once per project.
+`testsprite setup` prompts for your API key, verifies it, and installs the TestSprite verification skill into your agent's project configuration. Run it once per project.
 
 For CI or non-interactive environments:
 
 ```bash
-TESTSPRITE_API_KEY=$TS_KEY testsprite init --from-env --yes
+TESTSPRITE_API_KEY=$TS_KEY testsprite setup --from-env --yes
 ```
 
 ## Step 2: Find your project
@@ -133,7 +133,7 @@ Exit 0. The test is banked into the durable suite. The next time your agent ship
 
 ## Step 6: Let your agent drive it
 
-Install the TestSprite verification skill into your agent's project. `testsprite init` already did this, but you can re-run the agent install step standalone for any target:
+Install the TestSprite verification skill into your agent's project. `testsprite setup` already did this, but you can re-run the agent install step standalone for any target:
 
 ```bash
 testsprite agent install --target claude

--- a/cli/integrations/ci-cd.mdx
+++ b/cli/integrations/ci-cd.mdx
@@ -27,25 +27,19 @@ env:
   TESTSPRITE_API_KEY: ${{ secrets.TESTSPRITE_API_KEY }}
 ```
 
-The CLI resolves `TESTSPRITE_API_KEY` before the credentials file, so no `testsprite auth configure` step is needed in CI.
+The CLI resolves `TESTSPRITE_API_KEY` before the credentials file, so no `testsprite setup` step is needed in CI.
 
 <Warning>
 **Important:** Never inline an API key in a workflow file or a script committed to version control. Always source it from a secret store.
 </Warning>
 
-In most pipelines the env var alone is enough — you don't need to run any auth command. If you do need a credentials file on disk (for other tooling), write one non-interactively from the same env var:
+In most pipelines the env var alone is enough — you don't need to run any setup command. If you do need a credentials file on disk (for other tooling), write one non-interactively from the same env var with `--no-agent` to skip the skill install:
 
 ```bash
-testsprite auth configure --from-env
+testsprite setup --from-env --yes --no-agent
 ```
 
-Or run the full one-shot onboarding without the agent-skill install:
-
-```bash
-testsprite init --from-env --yes --no-agent
-```
-
-Both read `TESTSPRITE_API_KEY` from the environment and write `~/.testsprite/credentials`; `init` also verifies the key and prints an identity summary.
+This reads `TESTSPRITE_API_KEY` from the environment, verifies the key, writes `~/.testsprite/credentials`, and prints an identity summary.
 
 ## Gating on the result
 

--- a/cli/reference/command-reference.mdx
+++ b/cli/reference/command-reference.mdx
@@ -25,11 +25,10 @@ These flags must appear **before** the subcommand (e.g. `testsprite --output jso
 
 ```text
 testsprite
-├── init                              One-shot onboarding (configure key + install agent skill)
+├── setup                             One-shot onboarding (configure key + install agent skill)
 ├── auth
-│   ├── configure                     Store an API key (validated against /me before writing)
-│   ├── whoami  (alias: status)       Show user/key/scopes for active profile
-│   └── logout                        Remove credentials for active profile
+│   ├── status                        Show user/key/env/scopes for active profile
+│   └── remove                        Remove credentials for active profile
 ├── project
 │   ├── list                          List projects
 │   ├── get <project-id>              Get a project by id
@@ -64,11 +63,11 @@ testsprite
 
 <AccordionGroup>
 
-  <Accordion title="init — one-shot onboarding">
-    Chains `auth configure` → `auth whoami` → `agent install` and prints a unified summary. Installs credentials and the coding-agent skill in one step.
+  <Accordion title="setup — one-shot onboarding">
+    Configures your API key (validated against `GET /me` before writing) and installs the coding-agent skill in one step, then prints a unified summary. This is the only command that writes credentials.
 
     ```bash
-    testsprite init [options]
+    testsprite setup [options]
     ```
 
     | Flag | Description |
@@ -85,40 +84,26 @@ testsprite
     No TTY + no `--api-key` + no `--from-env` → exit 5. Use `--from-env` in CI.
     </Note>
 
-    Text output: `TestSprite initialized.` followed by profile, endpoint, scopes, agent result, and next steps.
+    Text output: `TestSprite initialized.` followed by profile, scopes, agent result, and next steps.
   </Accordion>
 
-  <Accordion title="auth — configure / whoami / logout">
-    Manage API keys and profiles.
+  <Accordion title="auth — status / remove">
+    Inspect and remove credentials. Credentials are written by `setup` (add `--no-agent` for credentials only).
 
-    **auth configure** — store an API key for the active profile. Validates against `GET /me` before writing; never overwrites a working profile with a rejected key.
+    **auth status** — show the user, API key, env, and scopes for the active profile. No flags.
 
     ```bash
-    testsprite auth configure [--from-env]
+    testsprite auth status
     ```
 
-    | Flag | Description |
-    | :--- | :--- |
-    | `--from-env` | Read `TESTSPRITE_API_KEY` from the environment |
-
-    Text output: `Profile "<name>" configured. Endpoint: <url>`
+    Text output lines: `userId / name / email / keyId / env / scopes`. Prints a `note:` line if write or run scopes are missing.
 
     ---
 
-    **auth whoami** (alias: `auth status`) — show the user, API key, and scopes for the active profile. No flags.
+    **auth remove** — remove credentials for the active profile. No flags.
 
     ```bash
-    testsprite auth whoami
-    ```
-
-    Text output lines: `userId / name / email / keyId / endpoint / env / scopes`. Prints a `note:` line if write or run scopes are missing.
-
-    ---
-
-    **auth logout** — remove credentials for the active profile. No flags.
-
-    ```bash
-    testsprite auth logout
+    testsprite auth remove
     ```
   </Accordion>
 

--- a/cli/reference/configuration.mdx
+++ b/cli/reference/configuration.mdx
@@ -37,7 +37,7 @@ api_key = sk-...
 api_key = sk-...
 ```
 
-Run `testsprite auth configure` to write a profile interactively. Use `--from-env` in CI to skip the prompt.
+Run `testsprite setup` to write a profile interactively. Use `--from-env` in CI to skip the prompt.
 
 ## Profiles
 
@@ -69,7 +69,7 @@ Environment variables override the credentials file but are overridden by their 
 | `TESTSPRITE_REQUEST_TIMEOUT_MS` | Per-request timeout in **milliseconds** | `--request-timeout` (seconds) |
 
 <Tip>
-In CI, set `TESTSPRITE_API_KEY` in your secrets store and pass `--from-env` to `testsprite init` or `testsprite auth configure`. The CLI never logs the key value.
+In CI, set `TESTSPRITE_API_KEY` in your secrets store and pass `--from-env` to `testsprite setup`. The CLI never logs the key value.
 </Tip>
 
 ## Resolution precedence

--- a/cli/reference/exit-codes.mdx
+++ b/cli/reference/exit-codes.mdx
@@ -59,7 +59,7 @@ Every command emits the same JSON error envelope when something goes wrong, rega
   "error": {
     "code": "AUTH_REQUIRED",
     "message": "Authentication is required.",
-    "nextAction": "Run `testsprite auth configure`, or set TESTSPRITE_API_KEY in the environment.",
+    "nextAction": "Run `testsprite setup`, or set TESTSPRITE_API_KEY and run `testsprite setup --from-env` for non-interactive flows.",
     "requestId": "req_2026_05_05_abc123",
     "details": {}
   }

--- a/cli/reference/whats-included.mdx
+++ b/cli/reference/whats-included.mdx
@@ -16,9 +16,9 @@ The TestSprite CLI is production-ready for the workflows listed below, with a st
 
 | Capability | Command |
 | :--- | :--- |
-| Configure an API key (with `--from-env` for CI) | `auth configure` |
-| Verify the active profile | `auth whoami` |
-| Remove credentials | `auth logout` |
+| Configure an API key and install the agent skill (with `--from-env` for CI) | `setup` |
+| Verify the active profile | `auth status` |
+| Remove credentials | `auth remove` |
 
 ### Projects
 
@@ -74,7 +74,7 @@ The TestSprite CLI is production-ready for the workflows listed below, with a st
 
 | Capability | Command |
 | :--- | :--- |
-| One command to configure credentials and install the agent skill, with a unified summary | `testsprite init` |
+| One command to configure credentials and install the agent skill, with a unified summary | `testsprite setup` |
 
 ### Coding-agent skill
 

--- a/cli/troubleshooting/common-issues.mdx
+++ b/cli/troubleshooting/common-issues.mdx
@@ -17,8 +17,8 @@ The global install didn't put the binary on your `PATH`, or it isn't installed y
 <Accordion title="Auth error (exit 3) / AUTH_FORBIDDEN" icon="key">
 The CLI couldn't authenticate, or your key is missing a scope.
 
-- Run `testsprite auth whoami` to see which profile, key, and scopes are active.
-- Reconfigure: `testsprite auth configure` (interactive) or `TESTSPRITE_API_KEY=sk-... testsprite auth configure --from-env`.
+- Run `testsprite auth status` to see which profile, key, and scopes are active.
+- Reconfigure: `testsprite setup --no-agent` (interactive) or `TESTSPRITE_API_KEY=sk-... testsprite setup --from-env --yes --no-agent`.
 - On `AUTH_FORBIDDEN`, the missing scope is named in `details.requiredScope`. Generate a new key with the full [scope set](/cli/core/authentication#scopes) from the [dashboard](/web-portal/admin/api-keys).
 - In CI, set `TESTSPRITE_API_KEY` in the environment — it overrides the credentials file.
 </Accordion>


### PR DESCRIPTION
## What

Syncs the CLI docs with the latest public `testsprite-cli` (**v0.1.2**), which consolidated the onboarding surface. The old command names are now hidden, deprecated aliases in the CLI, so the docs lead with the new ones throughout.

Same change as TestSprite/Docs-dev#20, applied to this repo.

### Command renames applied across the docs
| Old | New |
| :-- | :-- |
| `testsprite init` | `testsprite setup` |
| `testsprite auth configure` | folded into `setup` (`setup --no-agent` = credentials only) |
| `testsprite auth whoami` | `testsprite auth status` |
| `testsprite auth logout` | `testsprite auth remove` |

### Accuracy fixes (verified against the shipped CLI)
- Replaced the **fabricated `init` output sample** with the real `setup` summary (`TestSprite initialized.` + profile/env/scopes/agent/next-steps).
- Corrected the interactive prompt label to `TestSprite API key:`.
- Updated the `AUTH_REQUIRED` `nextAction` example to the real text (points at `testsprite setup`).
- `key-terms`: `setup` is no longer described as "purely local" (it calls `GET /me`).

## Files
12 files under `cli/` — getting-started (overview, installation, quickstart), core (authentication, agent-integration), reference (command-reference, configuration, exit-codes, whats-included), integrations (ci-cd), troubleshooting (common-issues), concepts (key-terms).

## Notes
- No `api_url`/endpoint configuration content was added.
- `--no-agent` still appears where it's genuinely the right flag (CI creds-file, reconfigure that would otherwise hit exit 6, the flag's own reference row). The onboarding-flow occurrences were left in place pending separate review.