### PR TITLE
docs(cli): sync from Docs-dev main — CLI 0.4.0

### DIFF
--- a/cli/concepts/key-terms.mdx
+++ b/cli/concepts/key-terms.mdx
@@ -210,6 +210,7 @@ A **failure bundle** is one self-consistent, run-scoped package of everything ne
     - The **test source** (plan or code) at run time
     - A **root-cause hypothesis** — the backend's best guess at what broke
     - A **recommended fix target** — which part of the code to look at
+    - For **backend tests**: the run's captured stdout (`apiOutput`) and Python traceback (`trace`)
 
     Every item in a bundle shares one `snapshotId`, so the agent is always reasoning over a single consistent moment in the run. The CLI refuses to stitch data from two different runs.
   </Tab>

--- a/cli/core/cancelling-runs.mdx
+++ b/cli/core/cancelling-runs.mdx
@@ -1,0 +1,133 @@
+---
+title: "Cancelling a Run"
+description: "Ctrl-C detaches, it never cancels — testsprite test cancel is the real stop button. What each one does to the run, your credits, and your exit codes."
+icon: "circle-stop"
+---
+
+Two different things can end your involvement with a run in flight, and they are deliberately not the same:
+
+| Action | What stops | What keeps going |
+| :--- | :--- | :--- |
+| **Ctrl-C** during `--wait` | Only your local CLI (it detaches) | The run — it keeps executing **and billing** on the server |
+| `testsprite test cancel <run-id>` | The run, server-side | Only work already started in the cloud, which finishes in the background with its result discarded — the run stays <kbd>cancelled</kbd> and the test is immediately free to run again |
+
+## Ctrl-C is a detach, not a cancel
+
+Pressing Ctrl-C while `test run --wait`, `test wait`, `test rerun --wait`, or `test flaky` is polling stops the *watching*, never the *run*. The CLI tells you exactly that on the way out:
+
+```text
+Interrupted (SIGINT). Run run_5c1d9a2b is still executing on the server and will keep running (and billing) until it finishes.
+  Re-attach with: testsprite test wait run_5c1d9a2b
+  Cancel with:    testsprite test cancel run_5c1d9a2b
+```
+
+Just like a `--timeout` expiry, the CLI prints a partial object (`{ "runId": "...", "status": "running" }`) to stdout before exiting, so a script that gets interrupted still captures the `runId`. The exit code is the conventional `128 + signal`: `130` for SIGINT (Ctrl-C), `143` for SIGTERM, `129` for SIGHUP.
+
+In `--output json` mode, stderr carries a machine-readable envelope instead of prose:
+
+```json
+{
+  "error": {
+    "code": "INTERRUPTED",
+    "message": "Interrupted by SIGINT.",
+    "nextAction": "The server-side run (if any) keeps executing and billing. Re-attach with: testsprite test wait <runId>, or stop it with: testsprite test cancel <runId> (runId is in the partial JSON on stdout).",
+    "requestId": "local",
+    "details": { "signal": "SIGINT" }
+  }
+}
+```
+
+<Note>
+A second Ctrl-C while the first is being handled exits immediately, no cleanup — the escape hatch when even the goodbye message is too slow.
+</Note>
+
+Interrupting a **batch** (`test run --all --wait`, multi-id `test wait`/`test rerun`) prints the same partial listing every run that was already dispatched, so nothing already billed goes unaccounted for.
+
+## Actually stopping a run
+
+```bash
+testsprite test cancel run_5c1d9a2b
+```
+
+The run flips to <kbd>cancelled</kbd> and the CLI prints the final run card:
+
+```text
+runId       run_5c1d9a2b
+testId      test_3a9f21c7
+status      cancelled
+createdAt   2026-07-10T02:11:04Z
+startedAt   2026-07-10T02:11:09Z
+failureKind user_cancel
+```
+
+What cancel does — and deliberately does not do:
+
+- **The test is immediately re-runnable.** Cancelling frees the test's run slot, so a follow-up `test run` won't hit the "run already in flight" conflict.
+- **The test's last verdict is untouched.** A test that was <kbd>passed</kbd> before the cancelled run stays <kbd>passed</kbd> — cancelling never overwrites history with a fake failure.
+- **No refund.** Credits charged when the run was triggered stay charged. Cancelling limits *future* cost (a pending auto-heal pass that hasn't engaged yet won't, so its fee is never charged) but never claws back a charge already made.
+- **The engine may finish in the background.** Work already started in the cloud can run to completion, but its result is discarded — it will never overwrite the <kbd>cancelled</kbd> status or the test's verdict.
+- **Cancelled runs stay in history.** `testsprite test result <test-id> --history` lists them like any other run.
+
+## Idempotent by design
+
+Cancelling the same run twice is a success, not an error — the second call exits `0` with an advisory:
+
+```text
+[advisory] run run_5c1d9a2b was already cancelled
+```
+
+That makes cancel safe to retry blindly from scripts and cleanup traps. Only two things are refused:
+
+| Situation | Exit | Why |
+| :--- | :--- | :--- |
+| Run already finished (<kbd>passed</kbd> / <kbd>failed</kbd> / <kbd>blocked</kbd>) | 6 | There is nothing left to stop — the verdict already exists |
+| Run ID unknown (or belongs to another tenant) | 4 | Check the ID |
+
+## Cancelling several runs at once
+
+`test cancel` is variadic — after interrupting a batch, paste every ID from the hint:
+
+```bash
+testsprite test cancel run_5c1d9a2b run_7f2e1c04 run_9a01b3e5
+```
+
+Multi-id output is a summary instead of a run card:
+
+```json
+{
+  "cancelled": ["run_5c1d9a2b", "run_7f2e1c04"],
+  "alreadyCancelled": [],
+  "conflicts": [{ "runId": "run_9a01b3e5", "status": "passed" }],
+  "notFound": [],
+  "errors": []
+}
+```
+
+The exit code reports the *worst* outcome: any `notFound` → `4` (a wrong ID is a caller bug worth failing loudly on), else any transport/auth `errors` → `1`, else any `conflicts` → `6`, else `0`. Runs that were fresh-cancelled or already cancelled both count as success.
+
+## CI cleanup pattern
+
+Cancel's idempotency makes it a natural `trap` target — detach honestly on interrupt, then stop the spend:
+
+```bash
+RUN_ID=$(testsprite test run test_3a9f21c7 --output json | jq -r '.runId')
+trap 'testsprite test cancel "$RUN_ID"' INT TERM
+testsprite test wait "$RUN_ID"
+```
+
+## Where to Go Next
+
+<Columns cols={2}>
+  <Card title="Running Tests" href="/cli/core/running-tests" icon="play">
+    Triggering runs, waiting for verdicts, and resuming
+  </Card>
+  <Card title="Exit Codes" href="/cli/reference/exit-codes" icon="list-ol">
+    The full exit-code and signal contract
+  </Card>
+  <Card title="Reading Results" href="/cli/core/reading-results" icon="list-check">
+    Run history, steps, and failure bundles
+  </Card>
+  <Card title="CI/CD Integration" href="/cli/integrations/ci-cd" icon="github">
+    Wire the CLI into GitHub Actions or any pipeline
+  </Card>
+</Columns>

--- a/cli/core/editing-tests.mdx
+++ b/cli/core/editing-tests.mdx
@@ -12,7 +12,7 @@ Once a test exists, you can change its metadata, replace its plan or code, or re
 
 ## Editing a test
 
-**Metadata** (name, description, priority) — use `test update`:
+**Metadata** (name, description, priority) — and, for backend tests, the **dependency declarations** (`--produces` / `--needs` / `--category`, repeatable; echoed back by `test get`) — use `test update`:
 
 ```bash
 testsprite test update test_3a9f21c7 --name "Guest checkout v2" --priority p0

--- a/cli/core/reading-results.mdx
+++ b/cli/core/reading-results.mdx
@@ -81,6 +81,10 @@ Add `--include-analysis` to attach the AI triage block — root-cause hypothesis
 testsprite test result test_3a9f21c7 --include-analysis
 ```
 
+<Note>
+For **backend tests**, the result also surfaces the run's captured stdout (`apiOutput`) and Python traceback (`trace`) — full content under `--output json` (and inside failure bundles as `result.json` / `failure.json`); text mode prints a bounded 20-line tail of each.
+</Note>
+
 The analysis fields are especially useful when piping to an agent:
 
 ```bash

--- a/cli/core/running-tests.mdx
+++ b/cli/core/running-tests.mdx
@@ -69,6 +69,20 @@ steps:      12 passed, 0 failed
 dashboard:  https://www.testsprite.com/dashboard/tests/proj_8f0f6/test/test_3a9f21c7
 ```
 
+## Interrupting a wait vs cancelling the run
+
+Ctrl-C during any `--wait` only detaches the CLI — **the run keeps executing (and billing) on the server**. The CLI exits `130` after printing the partial `{ "runId": "...", "status": "running" }` plus a re-attach hint and a cancel hint, so nothing is lost. To actually stop the run server-side:
+
+```bash
+testsprite test cancel run_5c1d9a2b
+```
+
+The run flips to <kbd>cancelled</kbd>, the test is immediately re-runnable, and the test's last verdict is untouched. Already-charged credits are not refunded.
+
+<Card title="Cancelling a Run" href="/cli/core/cancelling-runs" icon="circle-stop">
+  Detach vs cancel, idempotent re-cancel, multi-id summaries, and the CI cleanup pattern
+</Card>
+
 ## Overriding the target URL
 
 By default the run hits the URL stored on the project. Override it for a single run with `--target-url`:

--- a/cli/getting-started/quickstart-for-agents.mdx
+++ b/cli/getting-started/quickstart-for-agents.mdx
@@ -1,0 +1,182 @@
+---
+title: "Quickstart for Coding Agents"
+description: "Let your coding agent take this repo from zero to its first real test run — install once, then talk to your agent instead of the terminal."
+icon: "wand-magic-sparkles"
+---
+
+This page is for you if a coding agent — Claude Code, Codex, Cursor, Cline, Windsurf, Copilot — writes most of your code. You install the CLI once; from then on you describe what you want in plain language and **the agent drives the CLI**: it creates tests, triggers real cloud runs, reads the failure bundles, fixes the code, and reruns.
+
+By the end of this page your agent will have set up TestSprite in your repo, created a first test, and run it against your live app to a pass/fail verdict — without you typing another `testsprite` command.
+
+<Note>
+Prefer to type the commands yourself? The human-oriented [Quickstart](/cli/getting-started/quickstart) walks the same loop from the terminal.
+</Note>
+
+## Step 1: Install and run setup (the only terminal step)
+
+```bash
+npm install -g @testsprite/testsprite-cli
+testsprite setup
+```
+
+Run `testsprite setup` from your repo root. It chains three things:
+
+1. Prompts for your API key (created in the Portal under <kbd>Settings → API Keys</kbd> — see [API Keys](/web-portal/admin/api-keys)) and verifies it against the platform.
+2. Stores the key in `~/.testsprite/credentials`.
+3. Installs the **TestSprite agent skills** into your agent's project configuration — for Claude Code that's `.claude/skills/testsprite-verify/SKILL.md` and `.claude/skills/testsprite-onboard/SKILL.md`.
+
+Run it once per project. That's the entire manual surface — everything after this step happens through your agent.
+
+<Tip>
+You can even delegate this step: paste the two commands above into your agent and let it run them. `setup` supports a fully non-interactive form (`TESTSPRITE_API_KEY=$KEY testsprite setup --from-env --yes`) for exactly this.
+</Tip>
+
+<Note>
+The skill install is **pure-local** — it only writes files inside your repo, makes no network requests, and needs no credentials. Eight agent targets are supported (`claude`, `codex`, `cline`, `antigravity`, `kiro`, `windsurf`, `copilot`, `cursor`); see [Coding Agent Integration](/cli/core/agent-integration#supported-agents) for where each skill file lands and how to install for multiple agents at once.
+</Note>
+
+## Step 2: The two skills your agent just learned
+
+`testsprite setup` installed two skill files. They are the difference between an agent that *has* a CLI and an agent that *knows when and how to use it* — you never have to spell out the mechanics in a prompt.
+
+| Skill | Job | Your agent reaches for it when… |
+| :--- | :--- | :--- |
+| `testsprite-onboard` | Take a repo with **no tests yet** to a seeded, runnable suite with a first green run | Right after setup, or when you say "set up tests", "bootstrap", "get me started" |
+| `testsprite-verify` | Verify **every code change** with a real test run before the agent reports it done | A feature or fix lands and the agent is about to say "done" |
+
+### `testsprite-onboard` — seed a suite in an empty project
+
+**What it does.** The agent reads your codebase first — routes, handlers, the 4–8 most important user flows — instead of blindly crawling. It then creates a TestSprite project (frontend projects always get a target URL, plus login credentials if your flows need them), authors roughly 8–15 tests with concrete, observable assertions, batch-creates them, and **smoke-runs only the 2–3 highest-value happy paths**.
+
+**What you should expect to see:**
+
+- The agent asks for your deployed app URL (and login credentials, if needed) before creating a frontend project.
+- A report like: *"Your project now has 12 tests covering login, checkout, search… I smoke-ran 3 — here are the results and dashboard links."*
+- It will **not** auto-run the full suite — running everything costs credits, so it quotes the cost and leaves that choice to you.
+
+### `testsprite-verify` — verify every change before "done"
+
+**What it does.** After finishing a feature or fix, the agent preflights (`testsprite --version`, `testsprite auth status`), finds the right project, and picks the cheapest honest verification: rerun an existing test that covers the behavior, or author a new one (a plain-language plan file for frontend, a Python script for backend). It runs to a terminal verdict with `--wait`, and on failure pulls the failure bundle before deciding whether your change caused it.
+
+**What you should expect to see:**
+
+- The agent shows you the drafted plan or test code **before** creating it — one short confirmation, since creating writes to your project.
+- Every shipped change ends with a verdict line: test id, name, and `passed` / `failed` / `blocked` / `inconclusive`, plus a dashboard link.
+- On failure, a one-line root-cause hypothesis from the bundle — but the agent does **not** auto-fix on that hypothesis alone; it reads the evidence first.
+- If it *can't* run a test (no credentials, no reachable URL, repo not linked), it says so explicitly — *"shipped but unverified because X"* — rather than pretending. That honesty is by design.
+
+<Note>
+Both skills are versioned with the CLI. After upgrading, `testsprite agent status` tells you if an installed skill file is `stale` or was hand-`modified` — it exits `1` when anything needs attention, so it's CI-gateable. See [Checking skill health](/cli/core/agent-integration#checking-skill-health).
+</Note>
+
+## Step 3: What to say to your agent
+
+You don't need to name commands or flags — the skills carry the mechanics. Describe the **behavior** you care about and ask for a **verdict**. Copy-paste starters:
+
+**Your first test (right after setup):**
+
+```text
+Set up TestSprite for this repo and seed a starter test suite,
+then smoke-run the most important flow.
+```
+
+The agent onboards: creates the project, authors a suite from what it finds in your code, smoke-runs the top flows, and hands you dashboard links. You've gone from "installed" to "first real test run" in one prompt.
+
+**Verify a change (the everyday prompt):**
+
+```text
+Verify this change with TestSprite before you call it done.
+```
+
+The agent finds or creates the covering test, runs it against your deployed app, and reports the verdict.
+
+**Target a specific behavior:**
+
+```text
+Create a TestSprite test that covers the checkout happy path
+and run it to a verdict.
+```
+
+**Drive the fix loop:**
+
+```text
+The TestSprite run failed — pull the failure bundle, fix the code,
+and rerun until it passes.
+```
+
+<Tip>
+The phrase **"run it to a verdict"** is the useful one: it tells the agent a drafted-but-never-run plan doesn't count. The verify skill already enforces this — at least one terminal verdict per shipped change — but saying it keeps expectations aligned.
+</Tip>
+
+## Step 4: The loop, end to end
+
+Here's what a real session looks like once the skills are in place:
+
+<Steps>
+  <Step title="You ask for a feature">
+    *"Add a coupon-code field to checkout, and verify it with TestSprite."* The agent writes the code and gets it deployed somewhere reachable (a preview or staging URL) — the cloud runner tests deployed apps, not your working tree.
+  </Step>
+  <Step title="The agent creates and runs a test">
+    It drafts a plan describing the behavior in user-intent terms, shows it to you, then:
+
+    ```bash
+    testsprite test create --project proj_8f0f6 --type frontend \
+      --plan-from ./coupon-code.plan.json --run --wait --output json
+    ```
+
+    A real browser exercises your live app. Exit `0` = passed, `1` = failed.
+  </Step>
+  <Step title="On failure, it reads the bundle — not the tea leaves">
+    ```bash
+    testsprite test artifact get run_5c1d... --out ./.testsprite/failure
+    ```
+
+    One self-consistent bundle: the failing step and neighbors, DOM snapshots rendered as text, the test source, a root-cause hypothesis, and a recommended fix target — all from the same run.
+  </Step>
+  <Step title="It fixes and reruns until green">
+    ```bash
+    testsprite test rerun test_3a9f21c7 --wait
+    ```
+
+    Frontend reruns replay the saved script — free unless [auto-heal](/cli/core/rerun-and-auto-heal#auto-heal) repairs a drifted step. The confirmed pass is banked into your durable suite, so the next change **reruns** rather than recreates. Coverage compounds.
+  </Step>
+</Steps>
+
+<Card title="The Agent Loop" href="/cli/concepts/the-agent-loop" icon="arrows-rotate" horizontal>
+  Why the loop is designed this way — self-consistent bundles, compounding coverage, and the machine-readable contract underneath.
+</Card>
+
+## Step 5: Keep the agent on track
+
+A few conventions make the agent-driven flow reliable:
+
+**Pin the project.** The verify skill resolves which project to run against in priority order: the `TESTSPRITE_PROJECT_ID` environment variable → a `projectId` in `.testsprite/config.json` at the repo root → a name match from `testsprite project list` → asking you. The first two are conventions read by the *skill* (your agent), not by the CLI itself. Committing a pin removes the ambiguity:
+
+```json .testsprite/config.json
+{ "projectId": "proj_8f0f6" }
+```
+
+**Keep credentials in place.** The skills preflight `testsprite auth status` and stop with a clear message if the CLI is missing or unauthenticated — they never install software or configure keys behind your back. If your agent reports either, re-run Step 1.
+
+**Give it a deployed URL.** The CLI tests reachable `http(s)://` deployments and rejects `localhost`. If your change only runs locally, the agent will hand off to the [MCP Server](/mcp/getting-started/introduction) (which owns the localhost tunnel) when it's available, or honestly report the change as unverified — both are expected behavior, not failures.
+
+**Heed the nudge.** If you run test or auth commands in a repo where no verify skill is installed, the CLI prints a one-line reminder to stderr. Silence it with `TESTSPRITE_NO_SKILL_WARNING=1` if you're deliberately driving the CLI by hand.
+
+**Know the cost model.** Onboarding smoke-runs 2–3 tests, not the whole suite; full-suite runs are always your explicit call, with the credit cost stated up front. Frontend reruns of unchanged tests are free.
+
+## Where to Go Next
+
+<Columns cols={2}>
+  <Card title="Coding Agent Integration" href="/cli/core/agent-integration" icon="robot">
+    All eight agent targets, install flags, skill health checks, and the managed-section model for Codex
+  </Card>
+  <Card title="The Agent Loop" href="/cli/concepts/the-agent-loop" icon="arrows-rotate">
+    The concepts behind create → run → read → fix → rerun and why coverage compounds
+  </Card>
+  <Card title="Creating Tests" href="/cli/core/creating-tests" icon="file-circle-plus">
+    Plan files, code files, batch create, and dependency authoring — what your agent writes under the hood
+  </Card>
+  <Card title="Quickstart" href="/cli/getting-started/quickstart" icon="play">
+    The same loop, driven by a human at the terminal
+  </Card>
+</Columns>

--- a/cli/getting-started/quickstart.mdx
+++ b/cli/getting-started/quickstart.mdx
@@ -146,9 +146,14 @@ testsprite agent install --target claude
 
 The skill tells your agent when to run tests (after shipping a feature or fix), how to read the failure bundle, and how to loop until the test passes. From this point forward, your agent drives the create → run → failure get → fix → rerun loop without any human in the middle.
 
-<Card title="Agent Integration" href="/cli/core/agent-integration" icon="robot">
-  All eight supported agent targets (claude, cursor, cline, antigravity, kiro, windsurf, copilot, codex) and how the skills work
-</Card>
+<Columns cols={2}>
+  <Card title="Quickstart for Coding Agents" href="/cli/getting-started/quickstart-for-agents" icon="wand-magic-sparkles">
+    The agent-first walkthrough: what the skills do, what to say to your agent, and how the loop runs without you
+  </Card>
+  <Card title="Agent Integration" href="/cli/core/agent-integration" icon="robot">
+    All eight supported agent targets (claude, codex, cursor, cline, antigravity, kiro, windsurf, copilot) and how the skills work
+  </Card>
+</Columns>
 
 ## Where to Go Next
 

--- a/cli/reference/command-reference.mdx
+++ b/cli/reference/command-reference.mdx
@@ -35,6 +35,7 @@ testsprite
 │   ├── get <project-id>              Get a project by id
 │   ├── create                        Create a new project
 │   ├── update <project-id>           Update project metadata
+│   ├── delete <project-id>           Permanently delete a project and everything under it
 │   ├── credential <project-id>       Set the static backend credential for BE tests (free tier)
 │   └── auto-auth <project-id>        Configure recurring-token auto-refresh login for BE tests (Pro)
 ├── test
@@ -52,6 +53,7 @@ testsprite
 │   ├── diff <run-a> <run-b>          Compare two runs' verdicts and step deltas
 │   ├── run [test-id]                 Trigger a run (or --all for a wave-ordered batch)
 │   ├── wait <run-id...>              Wait for one or more runs to reach terminal status
+│   ├── cancel <run-id...>            Cancel queued/running runs (Ctrl-C only detaches)
 │   ├── rerun [test-ids...]           Re-execute as replay (FE no-credit; BE closure)
 │   ├── flaky <test-id>               Replay a test N times and report a stability score
 │   ├── code get <test-id>            Print generated test code
@@ -143,7 +145,7 @@ testsprite
     ```
   </Accordion>
 
-  <Accordion title="project — list / get / create / update">
+  <Accordion title="project — list / get / create / update / delete">
     Manage projects. A project is a named container with a target URL (frontend) or codebase (backend).
 
     **project list**
@@ -193,6 +195,15 @@ testsprite
 
     ```bash
     testsprite project update <project-id> --name "New Name"
+    ```
+
+    ---
+
+    **project delete `<project-id>`** — permanently delete a project and **everything under it**: its frontend/backend sub-projects, all their tests, and backend fixtures (mirrors the Portal's cascade delete). There is **no restore window**. `--confirm` is required — the CLI never prompts; absent it, exit 5 with a local validation error. `--dry-run` previews the response shape without a network call. Exit codes: 0 success, 3 auth, 4 not found (or already deleted), 5 validation.
+
+    ```bash
+    testsprite project delete <project-id> --confirm
+    testsprite project delete <project-id> --dry-run --output json
     ```
   </Accordion>
 
@@ -337,8 +348,8 @@ testsprite
     ```
   </Accordion>
 
-  <Accordion title="test update — update test metadata">
-    Update a test's name, description, or priority.
+  <Accordion title="test update — update test metadata & BE dependencies">
+    Update a test's name, description, or priority — and, for **backend tests**, its dependency declarations. Updated declarations are echoed back by `test get`.
 
     ```bash
     testsprite test update <test-id> [options]
@@ -349,6 +360,9 @@ testsprite
     | `--name <name>` | New title |
     | `--description <text>` | Up to 2000 characters |
     | `--priority <p0\|p1\|p2\|p3>` | Test priority |
+    | `--produces <var>` | BE only, repeatable — variable this test produces for the wave engine |
+    | `--needs <var>` | BE only, repeatable — variable this test consumes |
+    | `--category <setup\|main\|teardown>` | BE only — wave-ordering category |
     | `--idempotency-key <token>` | For safe retries |
   </Accordion>
 
@@ -401,7 +415,7 @@ testsprite
 
     ---
 
-    **test get `<test-id>`** — no flags. JSON: `{ id, projectId, projectName?, name, type, createdFrom, status, createdAt, updatedAt, planStepCount?, details?, priority? }`.
+    **test get `<test-id>`** — no flags. JSON: `{ id, projectId, projectName?, name, type, createdFrom, status, createdAt, updatedAt, planStepCount?, details?, priority?, produces?, consumes?, category? }` (the last three appear on backend tests with dependency declarations).
 
     ```bash
     testsprite test get <test-id>
@@ -439,7 +453,7 @@ testsprite
     | `--page-size <n>` | Default 20 (1–100) |
     | `--cursor <token>` | Pagination cursor |
 
-    Default JSON: `CliLatestResult`. With `--history`: `{ runs: RunHistoryItem[], nextCursor: string|null }`.
+    Default JSON: `CliLatestResult`. With `--history`: `{ runs: RunHistoryItem[], nextCursor: string|null }`. Backend tests also carry `apiOutput` (the run's captured stdout) and `trace` (Python traceback) — full content in JSON; text mode prints a bounded 20-line tail of each.
   </Accordion>
 
   <Accordion title="test diff — compare two runs">
@@ -507,6 +521,24 @@ testsprite
     ```
 
     Exit codes (multi-id): 0 all passed; 1 any failed/blocked/cancelled; 3 auth; 7 any timeout or per-member poll error (recorded as `error:<CODE>` in that run's row); 10 transport.
+  </Accordion>
+
+  <Accordion title="test cancel — stop queued/running runs">
+    Cancel one or more runs server-side. This is the real stop button — Ctrl-C during a `--wait` only detaches the CLI while the run keeps executing and billing.
+
+    ```bash
+    testsprite test cancel <run-id...>
+    ```
+
+    No flags beyond the global ones. Semantics: the run flips to <kbd>cancelled</kbd>, the test is immediately re-runnable, the test's last verdict is untouched, and already-charged credits are **not** refunded. Re-cancelling an already-cancelled run is a success (idempotent) with an `[advisory]` stderr line.
+
+    **One run ID**: exit codes 0 cancelled or already cancelled; 4 run not found; 6 run already finished (passed/failed/blocked).
+
+    **Several run IDs**: output is a `{ cancelled, alreadyCancelled, conflicts, notFound, errors }` summary. Exit precedence: any `notFound` → 4; else any `errors` → 1; else any `conflicts` → 6; else 0.
+
+    <Card title="Cancelling a Run" href="/cli/core/cancelling-runs" icon="circle-stop">
+      Detach vs cancel, billing semantics, and the CI cleanup pattern
+    </Card>
   </Accordion>
 
   <Accordion title="test rerun — cheap replay">

--- a/cli/reference/exit-codes.mdx
+++ b/cli/reference/exit-codes.mdx
@@ -22,9 +22,10 @@ Every `testsprite` command returns a stable exit code. Agents and CI pipelines b
 | `10` | Unavailable or transport failure — retriable with backoff |
 | `11` | Rate limited — honor the `Retry-After` header |
 | `12` | Insufficient credits — non-retriable; top up in the dashboard |
-| `129` | <kbd>SIGHUP</kbd> cancellation (terminal or SSH session closed) |
-| `130` | <kbd>SIGINT</kbd> cancellation (Ctrl-C) |
-| `143` | <kbd>SIGTERM</kbd> cancellation |
+| `14` | Client too old — the backend requires a newer CLI (HTTP 426 <kbd>CLIENT_TOO_OLD</kbd>); upgrade to proceed |
+| `129` | <kbd>SIGHUP</kbd> interrupt (terminal or SSH session closed) — CLI detaches; server-side runs keep executing |
+| `130` | <kbd>SIGINT</kbd> interrupt (Ctrl-C) — CLI detaches; server-side runs keep executing |
+| `143` | <kbd>SIGTERM</kbd> interrupt — CLI detaches; server-side runs keep executing |
 
 <Note>
 The `--help` and `--version` flags always exit 0. Flag-parse errors exit 5.
@@ -32,14 +33,18 @@ The `--help` and `--version` flags always exit 0. Flag-parse errors exit 5.
 
 ## Signals & pipes
 
-`129`, `130`, and `143` are the conventional `128 + signal` codes for SIGHUP, SIGINT, and SIGTERM respectively. Before exiting, the CLI prints one line to stderr:
+`129`, `130`, and `143` are the conventional `128 + signal` codes for SIGHUP, SIGINT, and SIGTERM respectively. When a signal lands while the CLI is polling a run (`--wait`, `test wait`, `test flaky`), it detaches gracefully: stdout gets the same partial object a `--timeout` would print (`{ "runId": "...", "status": "running" }`), and stderr names the run and both ways forward:
 
 ```text
-Interrupted (SIGINT). Any run already started keeps executing on the server; check it with `testsprite test list` or `testsprite test wait <runId>`.
+Interrupted (SIGINT). Run run_5c1d9a2b is still executing on the server and will keep running (and billing) until it finishes.
+  Re-attach with: testsprite test wait run_5c1d9a2b
+  Cancel with:    testsprite test cancel run_5c1d9a2b
 ```
 
+In `--output json` mode, stderr instead carries an `INTERRUPTED` error envelope with `details.signal` — deliberately outside the error-code table below, since no request failed. Outside a polling wait (at a prompt, mid-listing), the CLI prints a one-line generic reminder and exits with the same codes. A second signal exits immediately.
+
 <Warning>
-**Ctrl-C does not cancel the run.** The CLI only polls for status — the run itself keeps executing (and billing, where it applies) on the server whether or not the CLI is still attached. There is no cancel command today. Reattach with `testsprite test wait <run-id>`, or check `testsprite test list`.
+**Ctrl-C does not cancel the run.** The CLI only polls for status — the run itself keeps executing (and billing, where it applies) on the server whether or not the CLI is still attached. Reattach with `testsprite test wait <run-id>`, or actually stop it with [`testsprite test cancel <run-id>`](/cli/core/cancelling-runs).
 </Warning>
 
 Separately, if stdout is piped into a reader that closes early — `testsprite test list --output json | head -n 1` — the next write raises `EPIPE`. The CLI swallows it silently and exits `0`, the conventional outcome for "the reader went away," not a failure.
@@ -56,11 +61,12 @@ Every error response carries a machine-readable `code` string alongside the HTTP
 | `NOT_FOUND` | 404 | 4 | ID doesn't exist or belongs to another tenant | No |
 | `VALIDATION_ERROR` | 400 | 5 | Bad field, enum value, or cursor | No |
 | `PAYLOAD_TOO_LARGE` | 413 | 5 | Body over the size cap | No |
-| `CONFLICT` | 409 | 6 | Snapshot in flight or run already in flight | Yes — once, 1 s delay |
+| `CONFLICT` | 409 | 6 | Snapshot in flight, run already in flight, or cancelling a run that already finished | Yes — once, 1 s delay (cancel conflicts are not retried) |
 | `PRECONDITION_FAILED` | 412 | 6 | The test changed since you fetched it (newer `codeVersion`) | No — re-fetch then retry |
 | `IDEMPOTENCY_BODY_MISMATCH` | 409 | 6 | Same idempotency key reused with a different body | No |
 | `RATE_LIMITED` | 429 | 11 | 60 triggers/min/key exceeded | Yes — honor `Retry-After`, cap 3 retries |
 | `INSUFFICIENT_CREDITS` | 402 | 12 | Credit balance insufficient | No |
+| `CLIENT_TOO_OLD` | 426 | 14 | CLI below the backend's minimum supported version | No — upgrade the CLI |
 | `UNSUPPORTED` | 501 | 7 | Feature not on current backend version | No |
 | `INTERNAL` | 500 | 1 | Unhandled server error | Yes — once |
 | `UNAVAILABLE` | 503 | 10 | A downstream service is temporarily unavailable | Yes — exponential backoff, cap 4 retries |
@@ -98,7 +104,7 @@ The test-level **normalized status** reflects the outcome of the most recent com
 | <kbd>passed</kbd> | Latest completed run passed | Yes |
 | <kbd>failed</kbd> | Latest completed run failed (includes infra crash) | Yes |
 | <kbd>blocked</kbd> | Run rejected before a real verdict | Yes |
-| <kbd>cancelled</kbd> | Cancelled before verdict | Yes |
+| <kbd>cancelled</kbd> | In the enum for run-status symmetry, but never emitted at test level — [cancelling a run](/cli/core/cancelling-runs) leaves the test's previous status in place | n/a |
 | <kbd>unknown</kbd> | Backend cannot derive a status | n/a |
 
 ### Run status

--- a/cli/reference/whats-included.mdx
+++ b/cli/reference/whats-included.mdx
@@ -30,7 +30,7 @@ The TestSprite CLI is production-ready for the workflows listed below, with a st
 
 | Capability | Command |
 | :--- | :--- |
-| List, get, create, and update projects (frontend and backend types) | — |
+| List, get, create, update, and delete projects (frontend and backend types; `delete` cascades to everything under the project and requires `--confirm`) | — |
 | Set the static backend credential injected into every backend test (free tier) | `project credential` |
 | Configure recurring-token auto-refresh login for backend tests (Pro) | `project auto-auth` |
 

--- a/docs.json
+++ b/docs.json
@@ -166,6 +166,7 @@
               "cli/getting-started/overview",
               "cli/getting-started/installation",
               "cli/getting-started/quickstart",
+              "cli/getting-started/quickstart-for-agents",
               {
                 "group": "Concepts",
                 "icon": "book",
@@ -185,6 +186,7 @@
               "cli/core/creating-tests",
               "cli/core/editing-tests",
               "cli/core/running-tests",
+              "cli/core/cancelling-runs",
               "cli/core/reading-results",
               "cli/core/rerun-and-auto-heal",
               "cli/core/agent-integration"


### PR DESCRIPTION
Exact-tree mirror of Docs-dev `main` (commit-tree — byte-identical by construction). Drift check clean: no prod-only commits since the 07-10 mirror (#57), nothing reverted.

Carries the CLI 0.4.0 documentation wave (11 files, +397): Cancelling-a-Run page + honest-Ctrl-C sweep; `project delete`; BE dependency editability (`test update`/`test get`, editing-tests fix); exit 14 / `CLIENT_TOO_OLD` (426); backend `apiOutput`/`trace` in results + bundle docs; new Quickstart-for-Coding-Agents page.

npm `@testsprite/testsprite-cli@0.4.0` is live — docs now describe the published version.

Merge as a plain merge. Post-merge check (I'll run it): `v1.0^{tree} == Docs-dev main^{tree}`. Content was already code-owner-reviewed on Docs-dev (#23/#26); if the code-owner rule blocks this byte-identical mirror, admin-merge is the accepted path per the release SOP (v0.3.0 precedent: Docs #57).