### PR TITLE
docs(mcp): fix MCP tool name testsprite_bootstrap_tests -> testsprite_bootstrap

### DIFF
--- a/mcp/concepts/key-terms.mdx
+++ b/mcp/concepts/key-terms.mdx
@@ -206,7 +206,7 @@ TestSprite offers two scope options to balance between comprehensive coverage an
 | Speed | Takes longer | Fast feedback |
 | Coverage | Full coverage | Recent changes only |
 
-<Info>Set the scope in the bootstrapping page when you call the `testsprite_bootstrap_tests` tool. </Info>
+<Info>Set the scope in the bootstrapping page when you call the `testsprite_bootstrap` tool. </Info>
 
 <Card title="MCP Tools Reference" href="/mcp/core/tools" icon="wrench">
   Learn more about TestSprite MCP tools and commands

--- a/mcp/core/create-tests-new-feature.mdx
+++ b/mcp/core/create-tests-new-feature.mdx
@@ -36,7 +36,7 @@ flowchart LR
 
 ### Step 1: Bootstrap with Diff Scope
 
-The AI calls `testsprite_bootstrap_tests` with `testScope: "diff"` to initialize testing for changed code only.
+The AI calls `testsprite_bootstrap` with `testScope: "diff"` to initialize testing for changed code only.
 
  <Frame>
   <img src="../../images/bootstrap-diff.png"  alt="diff" />
@@ -61,7 +61,7 @@ The AI calls `testsprite_bootstrap_tests` with `testScope: "diff"` to initialize
 
 <CodeGroup>
 ```javascript Configuration expandable
-testsprite_bootstrap_tests({
+testsprite_bootstrap({
   localPort: 5173, // or your port
   type: "frontend", // or "backend"
   projectPath: "/absolute/path/to/your/project",

--- a/mcp/core/create-tests-new-project.mdx
+++ b/mcp/core/create-tests-new-project.mdx
@@ -46,7 +46,7 @@ flowchart LR
 
 ### Step 1: Bootstrap Testing Environment
 
-The AI calls `testsprite_bootstrap_tests` to initialize the testing environment.
+The AI calls `testsprite_bootstrap` to initialize the testing environment.
 
 <Info>Learn more about bootstrap configuration: [First Test: Configuration](/mcp/getting-started/first-test#step-3%3A-configuration-required)</Info>
 
@@ -62,7 +62,7 @@ The AI calls `testsprite_bootstrap_tests` to initialize the testing environment.
 
 <CodeGroup>
 ```javascript Configuration expandable
-testsprite_bootstrap_tests({
+testsprite_bootstrap({
   localPort: 5173, // or your port
   type: "frontend", // or "backend"
   projectPath: "/absolute/path/to/your/project",

--- a/mcp/core/tools.mdx
+++ b/mcp/core/tools.mdx
@@ -7,19 +7,19 @@ icon: "wrench"
 ## Core Tools
 TestSprite MCP Server provides **8 core tools** that work together to deliver comprehensive automated testing. Your AI assistant uses these tools automatically when you request testing.
 <AccordionGroup>
-  <Accordion title="testsprite_bootstrap_tests">
+  <Accordion title="testsprite_bootstrap">
     **Purpose:** Initialize testing environment and configuration
 
     **Parameters:**
     - `localPort` (number): Port where your application is running (default: 5173)
-    - `path` (string): Specifies a path you want to test directly, which isn’t accessible through navigation from other pages.
+    - `pathname` (string): Specifies a path you want to test directly, which isn’t accessible through navigation from other pages.
     - `type` (string): Project type - "frontend" or "backend" 
     - `projectPath` (string): Absolute path to your project directory
     - `testScope` (string): Testing scope - "codebase" or "diff"
 
     **Usage:**
     ```javascript expandable
-    testsprite_bootstrap_tests({
+    testsprite_bootstrap({
       localPort: 3000,
       type: "frontend",
       projectPath: "/Users/dev/my-project",
@@ -254,7 +254,7 @@ The tools work together in a specific sequence following the complete TestSprite
 <Card>
 ```mermaid
 graph TD
-    A[testsprite_bootstrap_tests] --> B[Read User PRD]
+    A[testsprite_bootstrap] --> B[Read User PRD]
     B --> C[testsprite_generate_code_summary]
     C --> D[testsprite_generate_standardized_prd]
     D --> E{Project Type?}

--- a/mcp/maintenance/cost-performance.mdx
+++ b/mcp/maintenance/cost-performance.mdx
@@ -30,7 +30,7 @@ Common code patterns for efficient test execution and cost optimization. Use the
 
 <CodeGroup>
 ```javascript Diff-only execution
-testsprite_bootstrap_tests({ testScope: "diff", ... })
+testsprite_bootstrap({ testScope: "diff", ... })
 ```
 ```javascript Subset during iteration
 testsprite_generate_code_and_execute({ testIds: ["TC005", "TC010"] })

--- a/mcp/troubleshooting/application-detection-issues.mdx
+++ b/mcp/troubleshooting/application-detection-issues.mdx
@@ -54,7 +54,7 @@ If you experience issues where **TestSprite can't access your running applicatio
     ```
     Update bootstrap call
     ```bash expandable
-    testsprite_bootstrap_tests ({
+    testsprite_bootstrap ({
       localPort: 3000,  // Use actual port
       type: "frontend",
       projectPath: "/path/to/project",


### PR DESCRIPTION
## What

The MCP docs reference the bootstrap tool as `testsprite_bootstrap_tests`, but the tool the MCP server actually registers is `testsprite_bootstrap` — and its first parameter is `pathname`, not `path`. An agent or user copy-pasting the documented name/parameter gets a "tool not found" (or a silently ignored parameter).

This corrects the tool name across the six files that reference it, and fixes the `path` → `pathname` parameter in the tool reference.

## Verified

Against the shipped plugin `@testsprite/testsprite-mcp@0.0.39`, via an MCP `tools/list` over stdio:

```
testsprite_bootstrap — params: [localPort, pathname, type, projectPath, testScope]
```

## Files

- `mcp/core/tools.mdx` — accordion title, parameter name, usage example, workflow diagram
- `mcp/concepts/key-terms.mdx`
- `mcp/core/create-tests-new-feature.mdx`
- `mcp/core/create-tests-new-project.mdx`
- `mcp/maintenance/cost-performance.mdx`
- `mcp/troubleshooting/application-detection-issues.mdx`

## Out of scope (flagged, not changed)

`mcp/core/tools.mdx` also lists `testsprite_rerun_tests (beta)` and omits `testsprite_check_account_info` compared to the current `tools/list`. Left untouched to keep this PR focused on the confirmed name/parameter drift — happy to follow up if you'd like those reconciled.
