### PR TITLE
docs(mcp): mirror tool-name parity fixes from Docs-dev main

### DIFF
--- a/mcp/concepts/key-terms.mdx
+++ b/mcp/concepts/key-terms.mdx
@@ -206,7 +206,7 @@ TestSprite offers two scope options to balance between comprehensive coverage an
 | Speed | Takes longer | Fast feedback |
 | Coverage | Full coverage | Recent changes only |
 
-<Info>Set the scope in the bootstrapping page when you call the `testsprite_bootstrap_tests` tool. </Info>
+<Info>Set the scope in the bootstrapping page when you call the `testsprite_bootstrap` tool. </Info>
 
 <Card title="MCP Tools Reference" href="/mcp/core/tools" icon="wrench">
   Learn more about TestSprite MCP tools and commands

--- a/mcp/core/create-tests-new-feature.mdx
+++ b/mcp/core/create-tests-new-feature.mdx
@@ -36,7 +36,7 @@ flowchart LR
 
 ### Step 1: Bootstrap with Diff Scope
 
-The AI calls `testsprite_bootstrap_tests` with `testScope: "diff"` to initialize testing for changed code only.
+The AI calls `testsprite_bootstrap` with `testScope: "diff"` to initialize testing for changed code only.
 
  <Frame>
   <img src="../../images/bootstrap-diff.png"  alt="diff" />
@@ -61,7 +61,7 @@ The AI calls `testsprite_bootstrap_tests` with `testScope: "diff"` to initialize
 
 <CodeGroup>
 ```javascript Configuration expandable
-testsprite_bootstrap_tests({
+testsprite_bootstrap({
   localPort: 5173, // or your port
   type: "frontend", // or "backend"
   projectPath: "/absolute/path/to/your/project",

--- a/mcp/core/create-tests-new-project.mdx
+++ b/mcp/core/create-tests-new-project.mdx
@@ -46,7 +46,7 @@ flowchart LR
 
 ### Step 1: Bootstrap Testing Environment
 
-The AI calls `testsprite_bootstrap_tests` to initialize the testing environment.
+The AI calls `testsprite_bootstrap` to initialize the testing environment.
 
 <Info>Learn more about bootstrap configuration: [First Test: Configuration](/mcp/getting-started/first-test#step-3%3A-configuration-required)</Info>
 
@@ -62,7 +62,7 @@ The AI calls `testsprite_bootstrap_tests` to initialize the testing environment.
 
 <CodeGroup>
 ```javascript Configuration expandable
-testsprite_bootstrap_tests({
+testsprite_bootstrap({
   localPort: 5173, // or your port
   type: "frontend", // or "backend"
   projectPath: "/absolute/path/to/your/project",

--- a/mcp/core/rerun-tests.mdx
+++ b/mcp/core/rerun-tests.mdx
@@ -21,7 +21,7 @@ This is useful after you fix a bug or change code and want to confirm nothing is
     Help me rerun all the tests with TestSprite.
     ```
 
-    TestSprite will automatically detect your existing project test suite and execute all of the tests again with the `testsprite_rerun_tests` tool. You'll see updated results directly in **your IDE** or **TestSprite dashboard**.
+    TestSprite will automatically detect your existing project test suite and execute all of the tests again with the `testsprite_generate_code_and_execute` tool (with an existing test plan, no re-planning happens). You'll see updated results directly in **your IDE** or **TestSprite dashboard**.
   </Tab>
   
   <Tab title="Rerun Subset of Tests">
@@ -31,7 +31,7 @@ This is useful after you fix a bug or change code and want to confirm nothing is
   <img src="../../images/rerun-subset.png"  alt="prd" />
 </Frame>
 
-    You can annotate the tests you want to rerun and pass their indexes directly to the `testsprite_rerun_tests` command. For example, to re-run only the 1st, 3rd, and 12th tests:
+    You can annotate the tests you want to rerun, and your AI assistant will pass their IDs to `testsprite_generate_code_and_execute` through the `testIds` parameter. For example, to re-run only the 1st, 3rd, and 12th tests:
 
     ```text Example Prompt
     Help me rerun the 1, 3 and 12th tests with TestSprite.

--- a/mcp/core/tools.mdx
+++ b/mcp/core/tools.mdx
@@ -7,19 +7,19 @@ icon: "wrench"
 ## Core Tools
 TestSprite MCP Server provides **8 core tools** that work together to deliver comprehensive automated testing. Your AI assistant uses these tools automatically when you request testing.
 <AccordionGroup>
-  <Accordion title="testsprite_bootstrap_tests">
+  <Accordion title="testsprite_bootstrap">
     **Purpose:** Initialize testing environment and configuration
 
     **Parameters:**
     - `localPort` (number): Port where your application is running (default: 5173)
-    - `path` (string): Specifies a path you want to test directly, which isn’t accessible through navigation from other pages.
+    - `pathname` (string): Specifies a path you want to test directly, which isn’t accessible through navigation from other pages.
     - `type` (string): Project type - "frontend" or "backend" 
     - `projectPath` (string): Absolute path to your project directory
     - `testScope` (string): Testing scope - "codebase" or "diff"
 
     **Usage:**
     ```javascript expandable
-    testsprite_bootstrap_tests({
+    testsprite_bootstrap({
       localPort: 3000,
       type: "frontend",
       projectPath: "/Users/dev/my-project",
@@ -215,35 +215,30 @@ TestSprite MCP Server provides **8 core tools** that work together to deliver co
     - Enables re-running updated tests with your changes
   </Accordion>
 
-  <Accordion title="testsprite_rerun_tests (beta)">
-    **Purpose:** Rerun the previously generated test cases
+  <Accordion title="testsprite_check_account_info">
+    **Purpose:** Check the current TestSprite account's name, email, subscription plan, and remaining credits
 
     **Parameters:**
-    - `projectPath` (string): Absolute path to your project directory
+    - None
 
     **Usage:**
     ```javascript
-    testsprite_rerun_tests({
-      projectPath: "/Users/dev/my-project"
-    })
+    testsprite_check_account_info()
     ```
 
     **Response:**
-    Executes the previously created tests and refines:
-    - Individual test files for each test case potentially if the previous run (during creation) was stopped early due to errors 
-    - Test execution results
-    - Bug reports and fix recommendations
-    - `testsprite_tests/tmp/test_results.json` with comprehensive results
-    - `tmp/report_prompt.json` for AI analysis
-    - `TestSprite_MCP_Test_Report.md` - human-readable test report
-    - `TestSprite_MCP_Test_Report.html` - HTML test report
+    Returns the account details associated with the configured API key:
+    - `firstName` / `lastName` - account holder name
+    - `emailAddress` - account email
+    - `subPlan` - current subscription plan
+    - `credits` - remaining credits
+
+    If no API key is configured, or the key is invalid, the tool returns a status message with a link to create a new key (the MCP server must be restarted after changing the key).
 
     **What it does:**
-    - Refines actual test code
-    - Executes previously created test cases against your running application
-    - Provides refined results with screenshots/videos according to the newest execution results
-    - Identifies bugs and suggests fixes
-    - Creates comprehensive test reports
+    - Verifies that the configured API key is valid
+    - Shows how many credits remain before running tests
+    - Helps diagnose authentication issues without leaving the IDE
   </Accordion>
 </AccordionGroup>
 
@@ -254,7 +249,7 @@ The tools work together in a specific sequence following the complete TestSprite
 <Card>
 ```mermaid
 graph TD
-    A[testsprite_bootstrap_tests] --> B[Read User PRD]
+    A[testsprite_bootstrap] --> B[Read User PRD]
     B --> C[testsprite_generate_code_summary]
     C --> D[testsprite_generate_standardized_prd]
     D --> E{Project Type?}

--- a/mcp/maintenance/cost-performance.mdx
+++ b/mcp/maintenance/cost-performance.mdx
@@ -30,13 +30,13 @@ Common code patterns for efficient test execution and cost optimization. Use the
 
 <CodeGroup>
 ```javascript Diff-only execution
-testsprite_bootstrap_tests({ testScope: "diff", ... })
+testsprite_bootstrap({ testScope: "diff", ... })
 ```
 ```javascript Subset during iteration
 testsprite_generate_code_and_execute({ testIds: ["TC005", "TC010"] })
 ```
 ```javascript Rerun without re-planning
-testsprite_rerun_tests({ projectPath: "/abs/path" })
+testsprite_generate_code_and_execute({ projectPath: "/abs/path" })
 ```
 </CodeGroup>
 

--- a/mcp/maintenance/test-maintenance.mdx
+++ b/mcp/maintenance/test-maintenance.mdx
@@ -48,7 +48,7 @@ Generate and run tests while coding—even before features are complete—to rev
 </Columns>
 
 <Tip>
-Rerun quickly: `testsprite_rerun_tests({ projectPath: "/abs/path" })`
+Rerun quickly: `testsprite_generate_code_and_execute({ projectPath: "/abs/path" })` — with an existing test plan, this reruns the suite without re-planning.
 </Tip>
 
 ## Best Practices

--- a/mcp/troubleshooting/application-detection-issues.mdx
+++ b/mcp/troubleshooting/application-detection-issues.mdx
@@ -54,7 +54,7 @@ If you experience issues where **TestSprite can't access your running applicatio
     ```
     Update bootstrap call
     ```bash expandable
-    testsprite_bootstrap_tests ({
+    testsprite_bootstrap ({
       localPort: 3000,  // Use actual port
       type: "frontend",
       projectPath: "/path/to/project",


### PR DESCRIPTION
Manual mirror of Docs-dev `main` into production, following the existing `sync/from-docs-dev-main-*` pattern.

Content was verified against the tool surface extracted from the published `@testsprite/testsprite-mcp@0.0.40` bundle — 8 real tools, bootstrap parameter is `pathname`. The live site currently documents two tools that do not exist and omits one that does, which is what a customer hit during first-time setup.

Merging this deploys to docs.testsprite.com via the Mintlify GitHub App.