### PR TITLE
docs(cli): sync from Docs-dev main

### DIFF
--- a/cli/concepts/key-terms.mdx
+++ b/cli/concepts/key-terms.mdx
@@ -172,7 +172,7 @@ Every run is tagged with the surface that triggered it. The **run source** lets 
   <Tab title="What credits are">
     Key rules:
     - A fresh `testsprite test run` **charges credits**.
-    - A `testsprite test rerun` verbatim replay does **not** charge credits.
+    - A `testsprite test rerun` is billed the same as a fresh run (0.5 credits frontend / 0.2 credits backend); legacy V2 accounts: a clean verbatim FE replay remains free.
     - Auto-heal is on by default and uses a small amount of credit only when it actually repairs a step — see [Rerun & Auto-Heal](/cli/core/rerun-and-auto-heal#auto-heal).
     - Backend test runs consume credits too, billed per your plan — the exact per-run cost isn't exposed by the API, so check `testsprite usage` or the pricing page before a large batch.
     - Insufficient balance → the CLI exits with a non-zero code. See [Exit Codes](/cli/reference/exit-codes) for the exact value and what to do.

--- a/cli/concepts/the-agent-loop.mdx
+++ b/cli/concepts/the-agent-loop.mdx
@@ -57,7 +57,7 @@ flowchart TD
     testsprite test rerun --all --project proj_8f0f6 --wait
     ```
 
-    Frontend reruns replay the saved script verbatim — free unless [auto-heal](/cli/core/rerun-and-auto-heal) engages.
+    Frontend reruns replay the saved script verbatim, billed as a rerun (same price as a fresh run) — [auto-heal](/cli/core/rerun-and-auto-heal) adds a small additional charge only if it engages.
   </Step>
   <Step title="Something failed → read the bundle, fix, replay">
     On exit 1, pull the failure bundle — one self-consistent package the agent can act on directly:
@@ -73,7 +73,7 @@ flowchart TD
 </Steps>
 
 <Tip>
-**Every pass is banked, not thrown away.** The rerun path is free and fast — use it aggressively. Your agent should rerun the relevant suite after every significant change, not just the test it created last.
+**Every pass is banked, not thrown away.** The rerun path is fast and billed the same as a fresh run — use it aggressively. Your agent should rerun the relevant suite after every significant change, not just the test it created last.
 </Tip>
 
 ## Why this design works

--- a/cli/core/agent-integration.mdx
+++ b/cli/core/agent-integration.mdx
@@ -8,7 +8,7 @@ icon: "robot"
 
 `testsprite agent install` writes two **skill files** into your repository by default:
 
-- **`testsprite-verify`** — the verification-loop skill. Once in place, your coding agent discovers that this project is TestSprite-tested and knows exactly how to drive the full loop on its own: describe a behavior as a plan file and create a test; trigger a real cloud run and wait for the verdict; on failure, pull one self-consistent bundle — failing step, DOM snapshots rendered as text, root-cause hypothesis, and recommended fix target; edit the code and replay cheaply.
+- **`testsprite-verify`** — the verification-loop skill. Once in place, your coding agent discovers that this project is TestSprite-tested and knows exactly how to drive the full loop on its own: describe a behavior as a plan file and create a test; trigger a real cloud run and wait for the verdict; on failure, pull one self-consistent bundle — failing step, DOM snapshots rendered as text, root-cause hypothesis, and recommended fix target; edit the code and replay it.
 - **`testsprite-onboard`** — the onboarding skill. Guides the agent through initial project setup (running `testsprite setup`, creating the first project and test) the first time TestSprite is used in a repo.
 
 Both skills are **pure-local**: `agent install` reads and writes only to your filesystem. It makes no network requests and requires no credentials.
@@ -147,7 +147,7 @@ Once the skill files are in place, a coding agent like Claude Code picks them up
 1. **Create** a test from a plan you or the agent authors — describing the behavior in intent terms, not driver code.
 2. **Run** it against the live app and wait for a pass/fail verdict.
 3. On failure, **pull the failure bundle** — one consistent artifact with everything needed to diagnose and fix.
-4. **Fix** the code, then **rerun** as a cheap verbatim replay.
+4. **Fix** the code, then **rerun** as a verbatim replay.
 
 The command sequence the agent follows:
 
@@ -162,7 +162,7 @@ testsprite test create \
 testsprite test failure get test_3a9f21c7 \
   --out ./.testsprite/failure
 
-# After fixing the code: replay cheaply (no credit for verbatim FE rerun)
+# After fixing the code: replay verbatim (billed as a rerun, same as a fresh run)
 testsprite test rerun test_3a9f21c7 --wait
 ```
 

--- a/cli/core/reading-results.mdx
+++ b/cli/core/reading-results.mdx
@@ -183,7 +183,7 @@ The response includes the language, framework, code content, and the `codeVersio
     Trigger runs, wait for verdicts, and understand exit codes
   </Card>
   <Card title="Rerun & Auto-Heal" href="/cli/core/rerun-and-auto-heal" icon="arrow-rotate-right">
-    Replay a test cheaply or let AI repair UI drift
+    Replay a test or let AI repair UI drift
   </Card>
   <Card title="Key Terms" href="/cli/concepts/key-terms" icon="book">
     runId, codeVersion, snapshotId, and the rest of the vocabulary

--- a/cli/core/rerun-and-auto-heal.mdx
+++ b/cli/core/rerun-and-auto-heal.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Rerun & Auto-Heal"
-description: "Replay a saved test cheaply, batch-rerun a whole suite, and let AI repair UI drift automatically — all from the CLI."
+description: "Replay a saved test, batch-rerun a whole suite, and let AI repair UI drift automatically — all from the CLI."
 icon: "arrow-rotate-right"
 ---
 
@@ -10,7 +10,7 @@ icon: "arrow-rotate-right"
 
 | Test type | What rerun executes |
 | :--- | :--- |
-| <kbd>Frontend tests</kbd> | Replay the saved Playwright script verbatim against the live app. No cloud credits are charged for a clean verbatim replay. |
+| <kbd>Frontend tests</kbd> | Replay the saved Playwright script verbatim against the live app. Billed the same as a fresh run — see [Credits](#credits) below. |
 | <kbd>Backend tests</kbd> | Re-run the full dependency closure: producers first, then the named test, then teardown — in the correct wave order. |
 
 This makes rerun the primary iteration loop once a test exists: fix code, rerun, read the verdict, repeat.
@@ -80,8 +80,12 @@ testsprite test rerun test_3a9f21c7 --skip-dependencies --wait
 When your app's UI has shifted since the test was last written — a button was renamed, a form gained an extra field, navigation was restructured — the verbatim script would fail even though the underlying feature still works. Auto-heal detects that drift and repairs the script so the test passes. If the feature itself is broken, the test stays <kbd>failed</kbd>.
 
 <Info>
-**Auto-heal is on by default for all CLI reruns.** It consumes a small amount of credit only when healing actually repairs a step — a clean verbatim replay that passes is free. Opt out with `--no-auto-heal`. See [Billing & Plans](/web-portal/admin/billing-and-plans) for current rates.
+**Auto-heal is on by default for all CLI reruns.** The rerun itself is billed the same as a fresh run regardless of whether healing engages; healing that actually repairs a step consumes an additional small amount of credit on top of that. Opt out with `--no-auto-heal` (rolling out on newer accounts — see the note below). See [Billing & Plans](/web-portal/admin/billing-and-plans) for current rates.
 </Info>
+
+<Note>
+The `--no-auto-heal` opt-out is still rolling out to accounts on the newer execution platform — if you rely on strictly disabling auto-heal (for example, in `test flaky`), verify with `testsprite auth status` and a sample rerun.
+</Note>
 
 To opt out for a specific rerun:
 
@@ -104,11 +108,13 @@ Auto-heal is ignored for backend tests — backend test failures are almost alwa
 
 | Action | Cost |
 | :--- | :--- |
-| Fresh `test run` (frontend) | Charged per run |
-| Fresh `test run` (backend) | Billed per your plan — check `testsprite usage` or the pricing page |
-| `test rerun` — verbatim replay passes | Free |
-| `test rerun` — auto-heal engages | a small amount of credit |
-| `test rerun` — backend closure | Consumes credits (amount not fixed — check `testsprite usage` or the pricing page) |
+| Fresh `test run` (frontend) | 0.5 credits per test executed |
+| Fresh `test run` (backend) | 0.2 credits per test executed, including any expanded dependency-closure members |
+| `test rerun` (frontend) | 0.5 credits — billed the same as a fresh run |
+| `test rerun` (backend) | 0.2 credits per test in the closure — billed the same as a fresh run |
+| `test rerun` — auto-heal engages | An additional small amount of credit, on top of the rerun charge |
+
+Reruns are billed identically to a fresh run — there is no discounted "replay" tier. (Legacy V2 accounts: a clean verbatim frontend rerun remains free.)
 
 When your credit balance is insufficient, the command exits with code 12. Top up credits in the Portal under <kbd>Settings → Billing</kbd>.
 

--- a/cli/core/running-tests.mdx
+++ b/cli/core/running-tests.mdx
@@ -179,7 +179,7 @@ The `dashboardUrl` is absent under `--dry-run`.
     Inspect steps, pull failure bundles, and navigate run history
   </Card>
   <Card title="Rerun & Auto-Heal" href="/cli/core/rerun-and-auto-heal" icon="arrow-rotate-right">
-    Replay a saved script cheaply, or let AI repair UI drift automatically
+    Replay a saved script, or let AI repair UI drift automatically
   </Card>
   <Card title="Exit Codes" href="/cli/reference/exit-codes" icon="square-code">
     Complete exit-code reference for scripts and CI pipelines

--- a/cli/getting-started/overview.mdx
+++ b/cli/getting-started/overview.mdx
@@ -83,7 +83,7 @@ What broke comes back as **one self-consistent failure bundle** the agent can ac
     The bundle contains the failing step and its neighbors, DOM snapshots rendered as text, the test source, a root-cause hypothesis, and a recommended fix target.
   </Step>
   <Step title="Fix and rerun — coverage compounds">
-    After fixing the code, replay the test cheaply (frontend replay costs no credits):
+    After fixing the code, replay the test — billed as a rerun, same as a fresh run:
 
     ```bash
     testsprite test rerun test_3a9f21c7 --wait

--- a/cli/getting-started/quickstart-for-agents.mdx
+++ b/cli/getting-started/quickstart-for-agents.mdx
@@ -138,7 +138,7 @@ Here's what a real session looks like once the skills are in place:
     testsprite test rerun test_3a9f21c7 --wait
     ```
 
-    Frontend reruns replay the saved script — free unless [auto-heal](/cli/core/rerun-and-auto-heal#auto-heal) repairs a drifted step. The confirmed pass is banked into your durable suite, so the next change **reruns** rather than recreates. Coverage compounds.
+    Frontend reruns replay the saved script, billed as a rerun (same price as a fresh run) — [auto-heal](/cli/core/rerun-and-auto-heal#auto-heal) adds a small additional charge only if it actually repairs a drifted step. The confirmed pass is banked into your durable suite, so the next change **reruns** rather than recreates. Coverage compounds.
   </Step>
 </Steps>
 
@@ -162,7 +162,7 @@ A few conventions make the agent-driven flow reliable:
 
 **Heed the nudge.** If you run test or auth commands in a repo where no verify skill is installed, the CLI prints a one-line reminder to stderr. Silence it with `TESTSPRITE_NO_SKILL_WARNING=1` if you're deliberately driving the CLI by hand.
 
-**Know the cost model.** Onboarding smoke-runs 2–3 tests, not the whole suite; full-suite runs are always your explicit call, with the credit cost stated up front. Frontend reruns of unchanged tests are free.
+**Know the cost model.** Onboarding smoke-runs 2–3 tests, not the whole suite; full-suite runs are always your explicit call, with the credit cost stated up front. Reruns of unchanged tests are billed the same as a fresh run (0.5 credits frontend / 0.2 credits backend) — see [Rerun & Auto-Heal](/cli/core/rerun-and-auto-heal#credits).
 
 ## Where to Go Next
 

--- a/cli/getting-started/quickstart.mdx
+++ b/cli/getting-started/quickstart.mdx
@@ -111,7 +111,7 @@ The bundle is self-contained: failing step and its neighbors, DOM snapshots rend
 
 ## Step 5: Fix and rerun
 
-After editing the code, replay the test cheaply. Frontend reruns replay the saved script — no credits charged for a verbatim pass:
+After editing the code, replay the test. Frontend reruns replay the saved script, billed as a rerun (same price as a fresh run):
 
 ```bash
 testsprite test rerun test_3a9f21c7 --wait

--- a/cli/integrations/ci-cd.mdx
+++ b/cli/integrations/ci-cd.mdx
@@ -143,6 +143,30 @@ For CI systems that render JUnit natively (GitHub Actions test reporters, GitLab
 - `--report-suite-name <name>` optionally overrides the `<testsuite name="...">` attribute; it defaults to `testsprite:<projectId>`.
 - Only `junit` is accepted for `--report` today.
 
+## GitHub-native annotations and summaries
+
+On GitHub Actions (`GITHUB_ACTIONS=true` — set automatically on every runner), a `--wait` run needs no extra flags to become CI-native:
+
+- Every non-passed run emits one `::error::` workflow-command line, so failures annotate the PR checks tab with the test id, status, and dashboard link.
+- A Markdown results table is appended to the job summary (`$GITHUB_STEP_SUMMARY`).
+
+This works on `test run <test-id> --wait`, `test run --all --wait`, and a batch `test rerun --wait`. Two optional flags extend it:
+
+- `--summary-file <path>` — also write a reduced machine summary JSON, `{total, passed, failed, timedOut, runs[]}`, for downstream steps that don't want to parse the full `--output json` stream.
+- `--gh-output` — force the annotations outside GitHub Actions, so you can preview the exact CI output locally.
+
+Everything is written even when the command exits non-zero — the annotations and summary land **before** the exit-code gate, so a red build still gets its explanation. All writes are best-effort: a failed write never changes the exit code. Tests that never dispatched (rate-deferred, conflicted, not found) appear as non-passed rows, so a partial batch can't read as all-passed.
+
+```yaml
+      - name: Run tests
+        run: |
+          testsprite test run --all --project "$PROJECT_ID" \
+            --wait --output json \
+            --summary-file ./summary.json > result.json
+        # No reporter action needed: failures annotate the PR automatically,
+        # and the results table appears on the workflow run's Summary page.
+```
+
 ## Parsing JSON output
 
 Pipe `--output json` to `jq` to extract fields for downstream steps:

--- a/cli/reference/command-reference.mdx
+++ b/cli/reference/command-reference.mdx
@@ -54,7 +54,7 @@ testsprite
 │   ├── run [test-id]                 Trigger a run (or --all for a wave-ordered batch)
 │   ├── wait <run-id...>              Wait for one or more runs to reach terminal status
 │   ├── cancel <run-id...>            Cancel queued/running runs (Ctrl-C only detaches)
-│   ├── rerun [test-ids...]           Re-execute as replay (FE no-credit; BE closure)
+│   ├── rerun [test-ids...]           Re-execute as replay (billed like a run)
 │   ├── flaky <test-id>               Replay a test N times and report a stability score
 │   ├── code get <test-id>            Print generated test code
 │   ├── code put <test-id>            Replace test code (etag/codeVersion guarded)
@@ -485,13 +485,15 @@ testsprite
     | `--project <id>` | **Yes** (with `--all`) | Project to run |
     | `--wait` | No | Poll until terminal or `--timeout` |
     | `--timeout <s>` | No | 1–3600, default 600 |
-    | `--target-url <url>` | No | Override project default URL (no localhost or private IPs). No effect with `--all`. |
+    | `--target-url <url>` | No | Override project default URL (no localhost or private IPs). No effect with `--all`. Not applied on V3-routed accounts (an `[advisory]` is printed; the run uses the configured project URL). |
     | `--idempotency-key <key>` | No | 1–256 characters |
     | `--filter <substr>` | No | With `--all`: only tests whose name contains this string (case-insensitive) |
     | `--max-concurrency <n>` | No | With `--all --wait`: max in-flight polls (1–100, default 50) |
     | `--report <format>` | No | With `--all --wait`: write a JUnit XML sidecar after polling. Only `junit` is accepted. |
     | `--report-file <path>` | No | Output path for `--report` (required when `--report` is set; written atomically) |
     | `--report-suite-name <name>` | No | Override the JUnit `<testsuite name="...">` (default `testsprite:<projectId>`) |
+    | `--gh-output` | No | With `--wait` (single test or `--all`): force GitHub-native `::error::` annotations outside GitHub Actions (auto-enabled when `GITHUB_ACTIONS=true`) — see [CI/CD](/cli/integrations/ci-cd#github-native-annotations-and-summaries) |
+    | `--summary-file <path>` | No | With `--wait` (single test or `--all`): also write the reduced machine summary JSON `{total, passed, failed, timedOut, runs[]}` |
 
     <Note>
     `--all` triggers every test in the project (each billed like any run). A project holds a single test type — frontend or backend — so don't mix both. On the legacy backend-only batch engine, frontend tests are skipped and reported in `skippedFrontend` with an advisory — run those individually with `test run <test-id>`.
@@ -541,8 +543,8 @@ testsprite
     </Card>
   </Accordion>
 
-  <Accordion title="test rerun — cheap replay">
-    Re-execute a test as a replay. Frontend replays the saved script (no credit charge). Backend re-runs the full dependency closure (producer + teardown tests).
+  <Accordion title="test rerun — replay a saved test">
+    Re-execute a test as a replay, billed the same as a fresh run (0.5 credits frontend / 0.2 credits backend). Frontend replays the saved script; backend re-runs the full dependency closure (producer + teardown tests).
 
     ```bash
     testsprite test rerun [test-ids...] [options]
@@ -557,16 +559,18 @@ testsprite
     | `--filter <substr>` | With `--all`: name substring match (case-insensitive) |
     | `--wait` | Poll until terminal |
     | `--timeout <s>` | 1–3600, default 600 |
-    | `--no-auto-heal` | Opt out of AI heal-on-drift for this FE rerun (default: auto-heal ON) |
+    | `--no-auto-heal` | Opt out of AI heal-on-drift for this FE rerun (default: auto-heal ON); still rolling out on newer accounts |
     | `--skip-dependencies` | BE only: rerun only the named test without the producer/teardown closure |
     | `--max-concurrency <n>` | 1–100, default 50 |
     | `--idempotency-key <key>` | For safe retries |
     | `--report <format>` | With a batch `--wait` (`--all` or several `test-ids...`): write a JUnit XML sidecar after polling. Only `junit` is accepted. |
     | `--report-file <path>` | Output path for `--report` (required when `--report` is set; written atomically) |
     | `--report-suite-name <name>` | Override the JUnit `<testsuite name="...">` (default `testsprite:<projectId>`) |
+    | `--gh-output` | With a batch `--wait`: force GitHub-native `::error::` annotations outside GitHub Actions (auto-enabled when `GITHUB_ACTIONS=true`) — see [CI/CD](/cli/integrations/ci-cd#github-native-annotations-and-summaries) |
+    | `--summary-file <path>` | With a batch `--wait`: also write the reduced machine summary JSON `{total, passed, failed, timedOut, runs[]}` |
 
     <Info>
-    Auto-heal is on by default and uses a small amount of credit only when it actually repairs a step — see [Rerun & Auto-Heal](/cli/core/rerun-and-auto-heal#auto-heal).
+    The rerun itself is billed the same as a fresh run; auto-heal adds a small amount of credit only when it actually repairs a step — see [Rerun & Auto-Heal](/cli/core/rerun-and-auto-heal#auto-heal).
     </Info>
   </Accordion>
 
@@ -592,7 +596,7 @@ testsprite
     ```
 
     <Note>
-    Frontend replays are free verbatim script replays. Backend replays re-run the full dependency closure and may cost credits — the CLI prints a one-line advisory before the first attempt.
+    Each replay is billed as a rerun, same as a fresh run (0.5 credits frontend / 0.2 credits backend) — the CLI prints a one-line advisory before the first backend attempt.
     </Note>
   </Accordion>
 

--- a/cli/reference/configuration.mdx
+++ b/cli/reference/configuration.mdx
@@ -102,7 +102,7 @@ This timeout governs single HTTP round-trips only. It does **not** affect the `-
 
 ## The dashboard link
 
-When a run completes, the JSON output includes an optional `dashboardUrl` field and text mode prints a `Dashboard:` line when the link is available. The field is present only when both `projectId` and `testId` are known client-side; it is not guaranteed on every completion. It deep-links directly into the Web Portal run view for that test.
+When a run completes — and on `test create` / `test create-batch` — the JSON output includes an optional `dashboardUrl` field and text mode prints a `Dashboard:` line when the link is available. It deep-links directly into the Web Portal view for that test. The backend builds the link when it can (it knows things the CLI cannot, like the correct portal origin and route for your account); when the backend offers no link, the CLI falls back to computing one from `projectId` + `testId` where both are known. The field is not guaranteed on every completion: when the backend reports that no correct link exists, the CLI prints no URL at all (with an `[advisory]` pointing at `test get <id>`) rather than a link that would 404.
 
 ```json
 {

--- a/cli/reference/whats-included.mdx
+++ b/cli/reference/whats-included.mdx
@@ -66,9 +66,9 @@ The TestSprite CLI is production-ready for the workflows listed below, with a st
 
 | Capability | Command |
 | :--- | :--- |
-| Replay a frontend test verbatim (no credit charge) or re-run a backend dependency closure | `test rerun` |
+| Replay a frontend test verbatim or re-run a backend dependency closure — billed the same as a fresh run | `test rerun` |
 | Rerun all tests matching a filter | `test rerun --all` |
-| Auto-heal on by default for frontend reruns — uses a small amount of credit only when AI healing actually engages; opt out | `--no-auto-heal` |
+| Auto-heal on by default for frontend reruns — the rerun is billed same as a fresh run; healing adds a small amount of credit only when it actually engages; opt out (rolling out on newer accounts) | `--no-auto-heal` |
 | Replay a test repeatedly with auto-heal off and report a stability score | `test flaky` |
 
 ### Reading results


### PR DESCRIPTION
Exact-tree mirror of Docs-dev `main` (33eda6a) onto `v1.0` — built with `commit-tree` on the prod parent, so merging applies Docs-dev's tree byte-for-byte.

**Drift check (mandatory, passed):** `v1.0`'s tip tree is identical to the 2026-08-11 mirror's tree — zero direct-to-prod edits since, nothing to absorb.

**Carries (13 files, +64/−30):**
- CLI 0.6.0 docs (Docs-dev #30): new *GitHub-native annotations and summaries* section in CI/CD; `--gh-output`/`--summary-file` rows in the run/rerun flag tables; V3 `--target-url` note; dashboard-link paragraph corrected to the server-link-wins contract
- Other Docs-dev content merged since the last mirror (rerun/auto-heal, quickstarts, agent-loop pages)

**Verify after merge (by tree, not log):** `git rev-parse 'v1.0^{tree}'` must equal Docs-dev `main^{tree}` (`14821faf59c478e27f4d019fb0996d966866e6b6`). Mintlify auto-deploys on merge; spot-check /cli/integrations/ci-cd, /cli/reference/command-reference, /cli/reference/configuration.